### PR TITLE
Fix email encryption type SSL/TLS

### DIFF
--- a/internal/common/email.go
+++ b/internal/common/email.go
@@ -61,7 +61,7 @@ func SendEmailWithAttachments(cfg MailConfig, sender, replyTo, subject, body, ht
 	}
 	switch cfg.Encryption {
 	case MailEncryptionTLS:
-		srv.Encryption = mail.EncryptionTLS
+		srv.Encryption = mail.EncryptionSSLTLS
 	case MailEncryptionStartTLS:
 		srv.Encryption = mail.EncryptionSTARTTLS
 	default: // MailEncryptionNone


### PR DESCRIPTION
`mail.EncryptionTLS` is deprecated and is the same like `mail.EncryptionSTARTTLS`

The correct here is `mail.EncryptionSSLTLS`