### PR TITLE
docker-compose - use logging limits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     image: h44z/wg-portal:1.0.6
     container_name: wg-portal
     restart: unless-stopped
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "3"
     cap_add:
       - NET_ADMIN
     network_mode: "host"


### PR DESCRIPTION
The ldap sync is very noisy and requires log limits and rotation.