### PR TITLE
fix: unscope update operations to avoid soft delete collisions

### DIFF
--- a/internal/users/manager.go
+++ b/internal/users/manager.go
@@ -153,7 +153,7 @@ func (m Manager) CreateUser(user *User) error {
 
 func (m Manager) UpdateUser(user *User) error {
 	user.Email = strings.ToLower(user.Email)
-	res := m.db.Save(user)
+	res := m.db.Unscoped().Save(user)
 	if res.Error != nil {
 		return errors.Wrapf(res.Error, "failed to update user %s", user.Email)
 	}


### PR DESCRIPTION
**Issue:** an LDAP user that is considered deleted by the internal database, will cause an update error on login about a unique key constraint collision.

Currently the code attempts to reset `deleted_at` value by updating user record, however the update query is generated in the form of `UPDATE users SET <bla bla bla>, deleted_at = NULL WHERE deleted_at IS NULL AND email = "<user email>";`. Since no user is found, a new one must be created. Primary key collision happens at this point.

Edit: **This is a workaround.** A better way to handle things, IMO, would be to designate user row differentiation to an integer autoincrement, which would make a soft-delete method feasible.