### PR TITLE
Implementation of recursive LDAP resolution for non-flat enterprise directory services

### DIFF
--- a/internal/ldap/config.go
+++ b/internal/ldap/config.go
@@ -27,6 +27,7 @@ type Config struct {
 
 	LoginFilter     string    `yaml:"loginFilter" envconfig:"LDAP_LOGIN_FILTER"` // {{login_identifier}} gets replaced with the login email address
 	SyncFilter      string    `yaml:"syncFilter" envconfig:"LDAP_SYNC_FILTER"`
+	SyncGroupFilter string    `yaml:"syncGroupFilter" envconfig:"LDAP_SYNC_GROUP_FILTER"`
 	AdminLdapGroup  string    `yaml:"adminGroup" envconfig:"LDAP_ADMIN_GROUP"` // Members of this group receive admin rights in WG-Portal
 	AdminLdapGroup_ *gldap.DN `yaml:"-"`
 	EveryoneAdmin   bool      `yaml:"everyoneAdmin" envconfig:"LDAP_EVERYONE_ADMIN"`

--- a/internal/ldap/ldap.go
+++ b/internal/ldap/ldap.go
@@ -8,6 +8,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+type ObjectType int64
+
+const (
+	Users  ObjectType = 1
+	Groups ObjectType = 2
+)
+
 type RawLdapData struct {
 	DN            string
 	Attributes    map[string]string
@@ -69,21 +76,34 @@ func Close(conn *ldap.Conn) {
 	}
 }
 
-func FindAllUsers(cfg *Config) ([]RawLdapData, error) {
+func FindAllObjects(cfg *Config, objType ObjectType) ([]RawLdapData, error) {
 	client, err := Open(cfg)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to open ldap connection")
 	}
 	defer Close(client)
 
-	// Search all users
-	attrs := []string{"dn", cfg.EmailAttribute, cfg.EmailAttribute, cfg.FirstNameAttribute, cfg.LastNameAttribute,
-		cfg.PhoneAttribute, cfg.GroupMemberAttribute}
-	searchRequest := ldap.NewSearchRequest(
-		cfg.BaseDN,
-		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-		cfg.SyncFilter, attrs, nil,
-	)
+	var searchRequest *ldap.SearchRequest
+	var attrs []string
+
+	if objType == Users {
+		// Search all users
+		attrs = []string{"dn", cfg.EmailAttribute, cfg.EmailAttribute, cfg.FirstNameAttribute, cfg.LastNameAttribute,
+			cfg.PhoneAttribute, cfg.GroupMemberAttribute}
+		searchRequest = ldap.NewSearchRequest(
+			cfg.BaseDN,
+			ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+			cfg.SyncFilter, attrs, nil,
+		)
+	} else if objType == Groups {
+		// Search all groups
+		attrs = []string{"dn", cfg.GroupMemberAttribute}
+		searchRequest = ldap.NewSearchRequest(
+			cfg.BaseDN,
+			ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+			cfg.SyncGroupFilter, attrs, nil,
+		)
+	}
 
 	sr, err := client.Search(searchRequest)
 	if err != nil {

--- a/internal/server/configuration.go
+++ b/internal/server/configuration.go
@@ -114,6 +114,7 @@ func NewConfig() *Config {
 	cfg.LDAP.AdminLdapGroup = "CN=WireGuardAdmins,OU=_O_IT,DC=COMPANY,DC=LOCAL"
 	cfg.LDAP.LoginFilter = "(&(objectClass=organizationalPerson)(mail={{login_identifier}})(!userAccountControl:1.2.840.113556.1.4.803:=2))"
 	cfg.LDAP.SyncFilter = "(&(objectClass=organizationalPerson)(!userAccountControl:1.2.840.113556.1.4.803:=2)(mail=*))"
+	cfg.LDAP.SyncGroupFilter = "(&(objectCategory=group))"
 
 	cfg.WG.DeviceNames = []string{"wg0"}
 	cfg.WG.DefaultDeviceName = "wg0"

--- a/internal/server/configuration.go
+++ b/internal/server/configuration.go
@@ -114,7 +114,7 @@ func NewConfig() *Config {
 	cfg.LDAP.AdminLdapGroup = "CN=WireGuardAdmins,OU=_O_IT,DC=COMPANY,DC=LOCAL"
 	cfg.LDAP.LoginFilter = "(&(objectClass=organizationalPerson)(mail={{login_identifier}})(!userAccountControl:1.2.840.113556.1.4.803:=2))"
 	cfg.LDAP.SyncFilter = "(&(objectClass=organizationalPerson)(!userAccountControl:1.2.840.113556.1.4.803:=2)(mail=*))"
-	cfg.LDAP.SyncGroupFilter = "(&(objectCategory=group))"
+	cfg.LDAP.SyncGroupFilter = "(&(objectClass=group))"
 
 	cfg.WG.DeviceNames = []string{"wg0"}
 	cfg.WG.DefaultDeviceName = "wg0"


### PR DESCRIPTION
This PR provides the ability for multi level group membership resolution.

Example (sub level means "member of" upper level):
```
WGPortal-Admin (L0)
\_ IT-Admin    (L1)
    |_ Alice   (L2)
    |_ Bob     (L2)
    \_ Eve     (L2)
```

Before this PR, the above mentioned structure was not possible, due to the fact, that the resolution of the group membership stopped at the "IT-Admin layer". After the PR, caused by the ability of recursive membership resolution, the group resolution stops at the point of the reached destination or the end of the membership tree.

This behavior of nested group resolution is the most common standard of group membership handling and is implemented by many applications communicating with active directory or LDAP out there.