### PR TITLE
/user/peer/{edit,create} - allow setting Identifier

### DIFF
--- a/assets/tpl/user_create_client.html
+++ b/assets/tpl/user_create_client.html
@@ -23,6 +23,10 @@
             <input type="hidden" name="uid" value="{{.Peer.UID}}">
             <div class="form-row">
                 <div class="form-group required col-md-12">
+                    <label for="server_Identifier">Identifier</label>
+                    <input type="text" name="identifier" class="form-control" id="server_Identifier" value="{{.Peer.Identifier}}" required>
+                </div>
+                <div class="form-group required col-md-12">
                     <label for="server_PublicKey">Public Key</label>
                     <input type="text" name="pubkey" class="form-control" id="server_PublicKey" value="{{.Peer.PublicKey}}" required>
                 </div>

--- a/assets/tpl/user_edit_client.html
+++ b/assets/tpl/user_edit_client.html
@@ -23,6 +23,10 @@
             <input type="hidden" name="uid"  value="{{.Peer.UID}}">
             <div class="form-row">
                 <div class="form-group required col-md-12">
+                    <label for="server_Identifier">Identifier</label>
+                    <input type="text" name="identifier" class="form-control" id="server_Identifier" value="{{.Peer.Identifier}}" required>
+                </div>
+                <div class="form-group required col-md-12">
                     <label for="server_PublicKey">Public Key</label>
                     <input type="text" name="pubkey" class="form-control" id="server_PublicKey" value="{{.Peer.PublicKey}}" required disabled="disabled">
                 </div>

--- a/internal/server/handlers_peer.go
+++ b/internal/server/handlers_peer.go
@@ -429,7 +429,6 @@ func (s *Server) PostUserCreatePeer(c *gin.Context) {
 	}
 
 	formPeer.Email = currentSession.Email
-	formPeer.Identifier = currentSession.Email
 	formPeer.DeviceType = wireguard.DeviceTypeServer
 
 	if err := c.ShouldBind(&formPeer); err != nil {


### PR DESCRIPTION
previously the identifier defaulted to the email for every peer created
