### PR TITLE
Peer interface address should match server's prefix length

### DIFF
--- a/internal/app/wireguard/wireguard_interfaces.go
+++ b/internal/app/wireguard/wireguard_interfaces.go
@@ -644,7 +644,7 @@ func (m Manager) importPeer(ctx context.Context, in *domain.Interface, p *domain
 	peer.InterfaceIdentifier = in.Identifier
 	peer.EndpointPublicKey = domain.StringConfigOption{Value: in.PublicKey, Overridable: true}
 	peer.AllowedIPsStr = domain.StringConfigOption{Value: in.PeerDefAllowedIPsStr, Overridable: true}
-	peer.Interface.Addresses = p.AllowedIPs // use allowed IP's as the peer IP's
+	peer.Interface.Addresses = p.AllowedIPs // use allowed IP's as the peer IP's TODO: Should this also match server interface address' prefix length?
 	peer.Interface.DnsStr = domain.StringConfigOption{Value: in.PeerDefDnsStr, Overridable: true}
 	peer.Interface.DnsSearchStr = domain.StringConfigOption{Value: in.PeerDefDnsSearchStr, Overridable: true}
 	peer.Interface.Mtu = domain.IntConfigOption{Value: in.PeerDefMtu, Overridable: true}

--- a/internal/app/wireguard/wireguard_peers.go
+++ b/internal/app/wireguard/wireguard_peers.go
@@ -310,8 +310,9 @@ func (m Manager) getFreshPeerIpConfig(ctx context.Context, iface *domain.Interfa
 		for {
 			ipConflict := false
 			for _, usedIp := range existingIps[network] {
-				if usedIp == ip {
+				if usedIp.Addr == ip.Addr {
 					ipConflict = true
+					break
 				}
 			}
 
@@ -326,7 +327,7 @@ func (m Manager) getFreshPeerIpConfig(ctx context.Context, iface *domain.Interfa
 			}
 		}
 
-		ips = append(ips, ip.HostAddr())
+		ips = append(ips, ip)
 	}
 
 	return

--- a/internal/domain/interface.go
+++ b/internal/domain/interface.go
@@ -103,7 +103,9 @@ func (i *Interface) GetAllowedIPs(peers []Peer) []Cidr {
 	var allowedCidrs []Cidr
 
 	for _, peer := range peers {
-		allowedCidrs = append(allowedCidrs, peer.Interface.Addresses...)
+		for _, ip := range peer.Interface.Addresses {
+			allowedCidrs = append(allowedCidrs, ip.HostAddr())
+		}
 		if peer.ExtraAllowedIPsStr != "" {
 			extraIPs, err := CidrsFromString(peer.ExtraAllowedIPsStr)
 			if err == nil {

--- a/internal/domain/peer.go
+++ b/internal/domain/peer.go
@@ -228,7 +228,10 @@ func MergeToPhysicalPeer(pp *PhysicalPeer, p *Peer) {
 		extraAllowedIPs, _ := CidrsFromString(p.ExtraAllowedIPsStr)
 		pp.AllowedIPs = append(allowedIPs, extraAllowedIPs...)
 	} else {
-		allowedIPs := p.Interface.Addresses
+		allowedIPs := make([]Cidr, len(p.Interface.Addresses))
+		for i, ip := range p.Interface.Addresses {
+			allowedIPs[i] = ip.HostAddr()
+		}
 		extraAllowedIPs, _ := CidrsFromString(p.ExtraAllowedIPsStr)
 		pp.AllowedIPs = append(allowedIPs, extraAllowedIPs...)
 	}


### PR DESCRIPTION
Say our server interface has address `10.11.12.1/24`.

Previous behavior: When creating a new peer, `getFreshPeerIpConfig` gives us `10.11.12.2/32`. which will bypass IP conflict detection for next peer and can't prevent the next peer getting `10.11.12.2` from `getFreshPeerIpConfig`. Also, the client can't contact `10.11.12.1` through wireguard (without manually adding a route) if its interface has address `10.11.12.2/32`.

Current behavior: `getFreshPeerIpConfig` gives us `10.11.12.2/24`, matching server interface address prefix length. Server side AllowedIPs and routes associated with this peer's interface address will have full prefix length `10.11.12.2/32` no matter what.