### PR TITLE
frontend: Treat peer DNS as StringSliceConfigOption

### DIFF
--- a/frontend/src/components/PeerEditModal.vue
+++ b/frontend/src/components/PeerEditModal.vue
@@ -245,12 +245,12 @@ function handleChangeDns(tags) {
     }
   })
   if(validInput) {
-    formData.value.Dns = tags
+    formData.value.Dns.Value = tags
   }
 }
 
 function handleChangeDnsSearch(tags) {
-  formData.value.DnsSearch = tags
+  formData.value.DnsSearch.Value = tags
 }
 
 async function save() {


### PR DESCRIPTION
Or there will be Error: json: cannot unmarshal array into Go struct field Peer.Dns of type model.StringSliceConfigOption

Also applies to peer DnsSearch field.