### PR TITLE
Feature (v1): add latest handshake data to API response

### DIFF
--- a/assets/tpl/admin_index.html
+++ b/assets/tpl/admin_index.html
@@ -181,7 +181,7 @@
                         {{if eq $.Device.Type "client"}}
                         <td>{{$p.Endpoint}}</td>
                         {{end}}
-                        <td><span data-toggle="tooltip" data-placement="left" title="" data-original-title="{{$p.LastHandshakeTime}}">{{$p.LastHandshake}}</span></td>
+                        <td><span data-toggle="tooltip" data-placement="left" title="" data-original-title="{{$p.LastHandshakeTime}}">{{$p.LastHandshakeRelativeTime}}</span></td>
                         <td>
                             {{if eq $.Session.IsAdmin true}}
                                 <a href="/admin/peer/edit?pkey={{$p.PublicKey}}" title="Edit peer"><i class="fas fa-cog"></i></a>

--- a/assets/tpl/admin_index.html
+++ b/assets/tpl/admin_index.html
@@ -181,7 +181,15 @@
                         {{if eq $.Device.Type "client"}}
                         <td>{{$p.Endpoint}}</td>
                         {{end}}
-                        <td><span data-toggle="tooltip" data-placement="left" title="" data-original-title="{{$p.LastHandshakeTime}}">{{$p.LastHandshakeRelativeTime}}</span></td>
+                        <td>
+                            <span
+                                data-toggle="tooltip"
+                                data-placement="left"
+                                title=""
+                                data-original-title="{{if $p.LastHandshakeTime.IsZero}}Never connected, or user is disabled.{{else}}{{formatTime $p.LastHandshakeTime}}{{end}}">
+                                {{$p.LastHandshakeRelativeTime}}
+                            </span>
+                        </td>
                         <td>
                             {{if eq $.Session.IsAdmin true}}
                                 <a href="/admin/peer/edit?pkey={{$p.PublicKey}}" title="Edit peer"><i class="fas fa-cog"></i></a>

--- a/assets/tpl/user_index.html
+++ b/assets/tpl/user_index.html
@@ -55,7 +55,7 @@
                         <td>{{$p.Email}}</td>
                         <td>{{$p.IPsStr}}</td>
                         <td>{{$p.DeviceName}}</td>
-                        <td><span data-toggle="tooltip" data-placement="left" title="" data-original-title="{{$p.LastHandshakeTime}}">{{$p.LastHandshake}}</span></td>
+                        <td><span data-toggle="tooltip" data-placement="left" title="" data-original-title="{{$p.LastHandshakeTime}}">{{$p.LastHandshakeRelativeTime}}</span></td>
                         {{if eq $.UserManagePeers true}}
                         <td>
                             <a href="/user/peer/edit?pkey={{$p.PublicKey}}" title="Edit peer"><i class="fas fa-cog"></i></a>

--- a/assets/tpl/user_index.html
+++ b/assets/tpl/user_index.html
@@ -55,7 +55,15 @@
                         <td>{{$p.Email}}</td>
                         <td>{{$p.IPsStr}}</td>
                         <td>{{$p.DeviceName}}</td>
-                        <td><span data-toggle="tooltip" data-placement="left" title="" data-original-title="{{$p.LastHandshakeTime}}">{{$p.LastHandshakeRelativeTime}}</span></td>
+                        <td>
+                            <span
+                                data-toggle="tooltip"
+                                data-placement="left"
+                                title=""
+                                data-original-title="{{if $p.LastHandshakeTime.IsZero}}Never connected, or user is disabled.{{else}}{{formatTime $p.LastHandshakeTime}}{{end}}">
+                                {{$p.LastHandshakeRelativeTime}}
+                            </span>
+                        </td>
                         {{if eq $.UserManagePeers true}}
                         <td>
                             <a href="/user/peer/edit?pkey={{$p.PublicKey}}" title="Edit peer"><i class="fas fa-cog"></i></a>

--- a/internal/common/util.go
+++ b/internal/common/util.go
@@ -93,3 +93,11 @@ func FormatDateHTML(t *time.Time) string {
 
 	return t.Format("2006-01-02")
 }
+
+func FormatToUnixTime(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+
+	return t.Format(time.UnixDate)
+}

--- a/internal/server/docs/docs.go
+++ b/internal/server/docs/docs.go
@@ -1512,6 +1512,9 @@ const docTemplate = `{
                 "IgnoreGlobalSettings": {
                     "type": "boolean"
                 },
+                "LastHandshakeTime": {
+                    "type": "string"
+                },
                 "Mtu": {
                     "description": "Global Device Settings (can be ignored, only make sense if device is in server mode)",
                     "type": "integer",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -128,6 +128,7 @@ func (s *Server) Setup(ctx context.Context) error {
 	s.server.Use(sessions.Sessions("authsession", cookieStore))
 	s.server.SetFuncMap(template.FuncMap{
 		"formatDate":  common.FormatDateHTML,
+		"formatTime":  common.FormatToUnixTime,
 		"formatBytes": common.ByteCountSI,
 		"urlEncode":   url.QueryEscape,
 		"startsWith":  strings.HasPrefix,


### PR DESCRIPTION
As user, I want to identify if peer is still alive by checking the time of latest handshake via API.
Unfortunately, **v1** doesn't provide this data unlike **v2**, but I've found **v2** to be quite unstable within my usage pattern. So it'd be nice to add such feature to **v1** too.

This PR updates JSON tags of `Peer` struct to include needed fields in Peers API response and modifies related HTML templates for using updated fields.