### PR TITLE
Use Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,13 @@ RUN echo "Building version '$ENV_BUILD_IDENTIFIER-$ENV_BUILD_VERSION' for platfo
 ######-
 # Here starts the main image
 ######-
-FROM scratch
+FROM alpine:3.19
+
+# Install OS-level dependencies
+RUN apk add --no-cache bash openresolv
 
 # Setup timezone
 ENV TZ=Europe/Vienna
-
-# Import linux stuff from builder.
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/group /etc/group
 
 # Copy binaries
 COPY --from=builder /build/dist/wg-portal /app/wg-portal


### PR DESCRIPTION
wgquick (apparently) depends on bash and openresolv.

Without those packages removing an Interface is impossible and causes an error message to appear in the webui:
- No Bash: exec complains about "bash no such file in $PATH"
- No openresolv: resolvconf -f -d *interface* returns with error 127

Not having a Shell in the container also makes debugging a lot more annoying.

This enables deletion of interfaces in the webui, eases debugging and only adds about 3MB in size.