### PR TITLE
fix issue 211: DNS Search Domain not applying

### DIFF
--- a/internal/app/configfile/tpl_files/wg_peer.tpl
+++ b/internal/app/configfile/tpl_files/wg_peer.tpl
@@ -25,7 +25,7 @@ Address = {{ CidrsToString .Peer.Interface.Addresses }}
 
 # Misc. settings (optional)
 {{- if .Peer.Interface.DnsStr.GetValue}}
-DNS = {{ .Peer.Interface.DnsStr.GetValue }}
+DNS = {{ .Peer.Interface.DnsStr.GetValue }} {{- if .Peer.Interface.DnsSearchStr.GetValue}}, {{ .Peer.Interface.DnsSearchStr.GetValue }} {{- end}}
 {{- end}}
 {{- if ne .Peer.Interface.Mtu.GetValue 0}}
 MTU = {{ .Peer.Interface.Mtu.GetValue }}


### PR DESCRIPTION
Added the DnsSearchStr to the template to include the DNS search domain in the generated config file.

Concerning issue: https://github.com/h44z/wg-portal/issues/211