### PR TITLE
Introducing Multiple Default Peers per User

### DIFF
--- a/internal/app/wireguard/wireguard.go
+++ b/internal/app/wireguard/wireguard.go
@@ -2,9 +2,10 @@ package wireguard
 
 import (
 	"context"
+	"time"
+
 	"github.com/h44z/wg-portal/internal/app"
 	"github.com/sirupsen/logrus"
-	"time"
 
 	evbus "github.com/vardius/message-bus"
 
@@ -46,7 +47,7 @@ func (m Manager) connectToMessageBus() {
 func (m Manager) handleUserCreationEvent(user *domain.User) {
 	logrus.Errorf("handling new user event for %s", user.Identifier)
 
-	if m.cfg.Core.CreateDefaultPeer {
+	if m.cfg.Core.CreateDefaultPeer && m.cfg.Core.DefaultPeersPerUser > 0 {
 		ctx := domain.SetUserInfo(context.Background(), domain.SystemAdminContextUserInfo())
 		err := m.CreateDefaultPeer(ctx, user)
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,9 +2,10 @@ package config
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"gopkg.in/yaml.v2"
 )
@@ -15,11 +16,13 @@ type Config struct {
 		AdminUser     string `yaml:"admin_user"`
 		AdminPassword string `yaml:"admin_password"`
 
-		EditableKeys            bool `yaml:"editable_keys"`
-		CreateDefaultPeer       bool `yaml:"create_default_peer"`
-		SelfProvisioningAllowed bool `yaml:"self_provisioning_allowed"`
-		ImportExisting          bool `yaml:"import_existing"`
-		RestoreState            bool `yaml:"restore_state"`
+		EditableKeys            bool     `yaml:"editable_keys"`
+		CreateDefaultPeer       bool     `yaml:"create_default_peer"`
+		DefaultPeersPerUser     int      `yaml:"default_peers_per_user"`
+		DefaultPeerNames        []string `yaml:"default_peer_names"`
+		SelfProvisioningAllowed bool     `yaml:"self_provisioning_allowed"`
+		ImportExisting          bool     `yaml:"import_existing"`
+		RestoreState            bool     `yaml:"restore_state"`
 	} `yaml:"core"`
 
 	Advanced struct {
@@ -84,6 +87,8 @@ func defaultConfig() *Config {
 
 	cfg.Core.ImportExisting = true
 	cfg.Core.RestoreState = true
+
+	cfg.Core.DefaultPeersPerUser = 1
 
 	cfg.Database = DatabaseConfig{
 		Type: "sqlite",


### PR DESCRIPTION
I've introduced two new configuration options: `default_peers_per_user` and `default_peer_names`. Now, when a user is created, the program will automatically generate a number of peers specified by `default_peers_per_user`. Should `default_peers_per_user` exceed the number of names provided in `default_peer_names`, the program will revert to the existing naming convention for any additional peers.

Should this enhancement be approved, I plan to update the documentation accordingly within this pull request.

To maintain compatibility with existing setups, I've set `default_peers_per_user` to default to 1. Furthermore, I've retained the `create_default_peer` option for now, although it could potentially be phased out. In the future, simply setting `default_peers_per_user` to 0 could serve as the indicator for whether or not peers should be created.