### PR TITLE
Fix: Password storage issue with PostgreSQL backend

### DIFF
--- a/internal/domain/base.go
+++ b/internal/domain/base.go
@@ -1,7 +1,10 @@
 package domain
 
 import (
+	"errors"
 	"time"
+
+	"database/sql/driver"
 )
 
 type BaseModel struct {
@@ -19,6 +22,26 @@ func (PrivateString) MarshalJSON() ([]byte, error) {
 
 func (PrivateString) String() string {
 	return ""
+}
+
+func (ps PrivateString) Value() (driver.Value, error) {
+	if len(ps) == 0 {
+        return nil, nil
+    }
+	return string(ps), nil
+}
+
+func (ps *PrivateString) Scan(value interface{}) error {
+    if value == nil {
+        *ps = ""
+        return nil
+    }
+    strValue, ok := value.(string)
+    if !ok {
+        return errors.New("invalid type for PrivateString")
+    }
+    *ps = PrivateString(strValue)
+    return nil
 }
 
 const (


### PR DESCRIPTION
## Description
This pull request addresses an issue where the password field of the User struct was being stored as an empty string in the PostgreSQL database, while working correctly with the SQLite backend (not sure why). The issue was caused by the custom `MarshalJSON` and `String` methods defined on the `PrivateString` type, which always returned an empty string.

## Changes
- Implemented custom `Value` and `Scan` methods for the `PrivateString` type to handle database serialization and deserialization correctly.
  - The `Value` method returns the actual string as a `driver.Value` when storing the user record in the database.
  - The `Scan` method properly assigns the string from the database to the `PrivateString` field when querying the user record.
- The custom methods ensure that the string is stored in the PostgreSQL database, while still keeping the password/hash hidden in the JSON and string representations of the `PrivateString` type.

## Testing
- Verified that the password field is stored correctly in the PostgreSQL database after applying the changes.
- Local user creation and login work normally.
- Local user login works normally after password changed by admin.
