### PR TITLE
Remove 'hidden'-attribute from email button

### DIFF
--- a/frontend/src/components/PeerViewModal.vue
+++ b/frontend/src/components/PeerViewModal.vue
@@ -212,7 +212,7 @@ function ConfigQrUrl() {
       <div class="flex-fill text-start">
         <button @click.prevent="download" type="button" class="btn btn-primary me-1">{{
           $t('modals.peer-view.button-download') }}</button>
-        <button @click.prevent="email" hidden type="button" class="btn btn-primary me-1">{{
+        <button @click.prevent="email" type="button" class="btn btn-primary me-1">{{
           $t('modals.peer-view.button-email') }}</button>
       </div>
       <button @click.prevent="close" type="button" class="btn btn-secondary">{{ $t('general.close') }}</button>


### PR DESCRIPTION
Hi,
with #214 the button to send configs via e-mail has been hidden. This MR simply unhides it again so mails can be send via the UI.
