### PR TITLE
Fix wrong default hooks for PreDown and PostDown on PreparePeer

### DIFF
--- a/internal/app/wireguard/wireguard_peers.go
+++ b/internal/app/wireguard/wireguard_peers.go
@@ -127,8 +127,8 @@ func (m Manager) PreparePeer(ctx context.Context, id domain.InterfaceIdentifier)
 			RoutingTable:      domain.NewStringConfigOption(iface.PeerDefRoutingTable, true),
 			PreUp:             domain.NewStringConfigOption(iface.PeerDefPreUp, true),
 			PostUp:            domain.NewStringConfigOption(iface.PeerDefPostUp, true),
-			PreDown:           domain.NewStringConfigOption(iface.PeerDefPreUp, true),
-			PostDown:          domain.NewStringConfigOption(iface.PeerDefPostUp, true),
+			PreDown:           domain.NewStringConfigOption(iface.PeerDefPreDown, true),
+			PostDown:          domain.NewStringConfigOption(iface.PeerDefPostDown, true),
 		},
 	}
 


### PR DESCRIPTION
Hi,

I noticed, that the default peer properties for the PreDown- and PostDown-hooks were falsely set to the Interfaces PreUp and PostUp properties. 
This leads to the wrong hooks being shown in the UI, when creating a new peer, which then leads to a wrong configuration generated, if you are not really cautious.

This simple change should fix this.

Best regards,
Tim