### PR TITLE
Fix not loading stats on interface change

### DIFF
--- a/frontend/src/views/InterfaceView.vue
+++ b/frontend/src/views/InterfaceView.vue
@@ -94,7 +94,7 @@ onMounted(async () => {
           <button class="input-group-text btn btn-primary" :title="$t('interfaces.button-add-interface')" @click.prevent="editInterfaceId='#NEW#'">
             <i class="fa-solid fa-plus-circle"></i>
           </button>
-          <select v-model="interfaces.selected" :disabled="interfaces.Count===0" class="form-select" @change="peers.LoadPeers()">
+          <select v-model="interfaces.selected" :disabled="interfaces.Count===0" class="form-select" @change="() => { peers.LoadPeers(); peers.LoadStats() }">
             <option v-if="interfaces.Count===0" value="nothing">{{ $t('interfaces.no-interface.default-selection') }}</option>
             <option v-for="iface in interfaces.All" :key="iface.Identifier" :value="iface.Identifier">{{ calculateInterfaceName(iface.Identifier,iface.DisplayName) }}</option>
           </select>


### PR DESCRIPTION
Hi,

When selecting another interface in the InterfaceView, the Statistics for the newly selected interface are not being loaded, resulting in a view with missing information about the connection state of the Peers.

To fix that, the method peers.LoadStats() is simply also called together with peers.LoadPeers() when the @change handler is activated on the interface selector element. This should be enough, as the peer-Store holds the state for the selected interface and peers.LoadStats() without an parameter loads the Statistics for the currently selected interface.

Best regards,
Tim