### PR TITLE
fix: autosave wireguard conf files

### DIFF
--- a/internal/app/configfile/tpl_files/wg_interface.tpl
+++ b/internal/app/configfile/tpl_files/wg_interface.tpl
@@ -60,6 +60,8 @@ PostDown = {{ .Interface.PostDown }}
 {{range .Peers}}
 {{- if not .IsDisabled}}
 [Peer]
+{{/* `friendly_name` used by https://github.com/MindFlavor/prometheus_wireguard_exporter */ -}}
+# friendly_name = {{ .DisplayName }}
 # -WGP- Peer: {{.Identifier}}
 # -WGP- Created: {{.CreatedAt}}
 # -WGP- Updated: {{.UpdatedAt}}

--- a/internal/app/wireguard/wireguard_peers.go
+++ b/internal/app/wireguard/wireguard_peers.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/h44z/wg-portal/internal"
 	"github.com/h44z/wg-portal/internal/app"
 	"github.com/h44z/wg-portal/internal/domain"
 	"github.com/sirupsen/logrus"
-	"time"
 )
 
 func (m Manager) CreateDefaultPeer(ctx context.Context, userId domain.UserIdentifier) error {
@@ -252,6 +253,11 @@ func (m Manager) DeletePeer(ctx context.Context, id domain.PeerIdentifier) error
 	if err != nil {
 		return fmt.Errorf("failed to delete peer %s: %w", id, err)
 	}
+
+	// Update routes after peers have changed
+	m.bus.Publish(app.TopicRouteUpdate, "peers updated")
+	// Update interface after peers have changed
+	m.bus.Publish(app.TopicPeerInterfaceUpdated, peer.InterfaceIdentifier)
 
 	return nil
 }


### PR DESCRIPTION
- Fix subscription to Interface and Peer updates topics
- Remove admin permissions validation
- Update file on peer deletion
- Change save condition to configured storage path only, as initialized interface is not nil
- Added `friendly_name` comment to peer config for [prometheus_wireguard_exporter](https://github.com/MindFlavor/prometheus_wireguard_exporter)

Resolves #249 
Resolves #247 
Partially #207 