### PR TITLE
UX: Config downloads without .txt extension

### DIFF
--- a/frontend/src/components/PeerViewModal.vue
+++ b/frontend/src/components/PeerViewModal.vue
@@ -100,7 +100,7 @@ function download() {
   let text = configString.value
 
   let element = document.createElement('a')
-  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text))
+  element.setAttribute('href', 'data:application/octet-stream;charset=utf-8,' + encodeURIComponent(text))
   element.setAttribute('download', filename)
 
   element.style.display = 'none'

--- a/frontend/src/views/InterfaceView.vue
+++ b/frontend/src/views/InterfaceView.vue
@@ -52,7 +52,7 @@ async function download() {
   let text = interfaces.configuration
 
   let element = document.createElement('a')
-  element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text))
+  element.setAttribute('href', 'data:application/octet-stream;charset=utf-8,' + encodeURIComponent(text))
   element.setAttribute('download', filename)
 
   element.style.display = 'none'


### PR DESCRIPTION
This is a sort of improvement where files downloaded using JavaScript have their extension kept as-is (without appending an extra ".txt" to the end of the file name).

_Please note that while this did fix the issue for me on Brave for Android and Brave for Linux, I am unsure of implications that might be caused by not wrapping the following text into a base64 encoding or anything alike._