### PR TITLE
chart: update monitoring resources

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -16,7 +16,7 @@ annotations:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,6 +1,6 @@
 # wg-portal
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 WireGuard Configuration Portal with LDAP, OAuth, OIDC authentication
 

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -105,7 +105,7 @@ The [Values](#values) section lists the parameters that can be configured during
 | serviceAccount.annotations | object | `{}` | Service account annotations |
 | serviceAccount.automount | bool | `false` | Automatically mount a ServiceAccount's API credentials |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| monitoring.enabled | bool | `true` | Enable Prometheus monitoring. |
+| monitoring.enabled | bool | `false` | Enable Prometheus monitoring. |
 | monitoring.apiVersion | string | `"monitoring.coreos.com/v1"` | API version of the Prometheus resource. Use `azmonitoring.coreos.com/v1` for Azure Managed Prometheus. |
 | monitoring.kind | string | `"PodMonitor"` | Kind of the Prometheus resource. Could be `PodMonitor` or `ServiceMonitor`. |
 | monitoring.labels | object | `{}` | Resource labels. |

--- a/deploy/helm/files/dashboard.json
+++ b/deploy/helm/files/dashboard.json
@@ -219,7 +219,7 @@
           "expr": "sum by (instance, interface) (rate(wireguard_interface_received_bytes_total{instance=\"$instance\", interface=~\"$interface\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
-          "interval": "$__rate_interval",
+          "interval": "",
           "legendFormat": "Received {{interface}}",
           "range": true,
           "refId": "A"
@@ -233,7 +233,7 @@
           "expr": "sum by (instance, interface) (rate(wireguard_interface_sent_bytes_total{instance=\"$instance\", interface=~\"$interface\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
-          "interval": "$__rate_interval",
+          "interval": "",
           "legendFormat": "Sent {{interface}}",
           "range": true,
           "refId": "B"
@@ -337,7 +337,7 @@
           "expr": "sum by (name, instance, interface) (rate(wireguard_peer_received_bytes_total{instance=\"$instance\", interface=~\"$interface\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
-          "interval": "$__rate_interval",
+          "interval": "$interval",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
@@ -441,7 +441,7 @@
           "expr": "sum by (instance, interface, name) (rate(wireguard_peer_sent_bytes_total{instance=\"$instance\", interface=~\"$interface\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
-          "interval": "$__rate_interval",
+          "interval": "$interval",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
@@ -519,9 +519,9 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(wireguard_peer_up{instance=\"$instance\", interface=~\"$interface\"}) by (id, instance, interface, name,)",
+          "expr": "sum by(name) (wireguard_peer_up{instance=\"$instance\", interface=~\"$interface\"})",
           "instant": false,
-          "interval": "$__rate_interval",
+          "interval": "$interval",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
@@ -662,7 +662,6 @@
           }
         ]
       },
-      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -797,7 +796,7 @@
       "type": "table"
     }
   ],
-  "refresh": "30s",
+  "refresh": "1m",
   "tags": [
     "wireguard",
     "vpn"
@@ -865,6 +864,44 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "current": {
+          "text": "2m",
+          "value": "2m"
+        },
+        "description": "",
+        "label": "Step Interval",
+        "name": "interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": true,
+            "text": "2m",
+            "value": "2m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          }
+        ],
+        "query": "30s,1m,2m,5m,10m",
+        "type": "custom"
       }
     ]
   },

--- a/deploy/helm/templates/monitoring.yaml
+++ b/deploy/helm/templates/monitoring.yaml
@@ -29,7 +29,7 @@ spec:
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: instance
       {{- with .relabelings }}
-      {{- toYamlPretty  . | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}

--- a/deploy/helm/templates/monitoring.yaml
+++ b/deploy/helm/templates/monitoring.yaml
@@ -23,8 +23,13 @@ spec:
       {{- with .metricRelabelings }}
       metricRelabelings: {{- toYaml . | nindent 8 }}
       {{- end }}
+      relabelings:
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_pod_label_app_kubernetes_io_name
+          targetLabel: instance
       {{- with .relabelings }}
-      relabelings: {{- toYaml . | nindent 8 }}
+      {{- toYamlPretty  . | nindent 8 }}
       {{- end }}
       {{- with .scrapeTimeout }}
       scrapeTimeout: {{ . }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -207,7 +207,7 @@ serviceAccount:
 
 monitoring:
   # -- Enable Prometheus monitoring.
-  enabled: true
+  enabled: false
   # -- API version of the Prometheus resource.
   # Use `azmonitoring.coreos.com/v1` for Azure Managed Prometheus.
   apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
This pull request includes several changes to the Helm chart and associated files to update configurations and improve monitoring settings. The most important changes include modifying monitoring settings, and making adjustments to the Grafana dashboard configuration.

### Monitoring settings:
* Disabled rendering of Prometheus resources by default.
* Added a new relabeling configuration to replace the `instance` label based on the `app_kubernetes_io_name` label. Instance will be displayed as Helm release name instead of pod IP address.

### Grafana dashboard configuration:
* Changed the `interval` field for several metrics queries from `"$__rate_interval"` to `"$interval"`.
* Updated the `refresh` interval from `30s` to `1m`.
* Added a new variable for `Step Interval` with default value `2m`.

### Chart version update:
* Updated the chart version from `0.4.0` to `0.5.0`.