### PR TITLE
[chart] Fix default configurations

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -16,7 +16,7 @@ annotations:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,6 +1,6 @@
 # wg-portal
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2](https://img.shields.io/badge/AppVersion-v2-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2](https://img.shields.io/badge/AppVersion-v2-informational?style=flat-square)
 
 WireGuard Configuration Portal with LDAP, OAuth, OIDC authentication
 
@@ -34,7 +34,7 @@ The [Values](#values) section lists the parameters that can be configured during
 | extraDeploy | list | `[]` | Array of extra objects to deploy with the release |
 | config.advanced | tpl/object | `{}` | [Advanced configuration](https://wgportal.org/latest/documentation/configuration/overview/#advanced) options. |
 | config.auth | tpl/object | `{}` | [Auth configuration](https://wgportal.org/latest/documentation/configuration/overview/#auth) options. |
-| config.core | tpl/object | `{}` | [Core configuration](https://wgportal.org/latest/documentation/configuration/overview/#core) options.<br> If external admins in `auth` are not defined and there are no `admin_user` and `admin_password` defined here, the default credentials will be generated. |
+| config.core | tpl/object | `{}` | [Core configuration](https://wgportal.org/latest/documentation/configuration/overview/#core) options.<br> If external admins in `auth` are defined and there are no `admin_user` and `admin_password` defined here, the default admin account will be disabled. |
 | config.database | tpl/object | `{}` | [Database configuration](https://wgportal.org/latest/documentation/configuration/overview/#database) options |
 | config.mail | tpl/object | `{}` | [Mail configuration](https://wgportal.org/latest/documentation/configuration/overview/#mail) options |
 | config.statistics | tpl/object | `{}` | [Statistics configuration](https://wgportal.org/latest/documentation/configuration/overview/#statistics) options |
@@ -82,7 +82,7 @@ The [Values](#values) section lists the parameters that can be configured during
 | ingress.className | string | `""` | Ingress class name |
 | ingress.annotations | object | `{}` | Ingress annotations |
 | ingress.tls | bool | `false` | Ingress TLS configuration. Enable certificate resource or add ingress annotation to create required secret |
-| certificate.enabled | bool | `false` | Specifies whether a certificate resource should be created |
+| certificate.enabled | bool | `false` | Specifies whether a certificate resource should be created. If enabled, certificate will be used for the web. |
 | certificate.issuer.name | string | `""` | Certificate issuer name |
 | certificate.issuer.kind | string | `""` | Certificate issuer kind (ClusterIssuer or Issuer) |
 | certificate.issuer.group | string | `"cert-manager.io"` | Certificate issuer group |

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -62,9 +62,9 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Define default admin credentials
+Disables default admin credentials
 If external auth is enabled and has admin group mappings,
-the admin_user and admin_password values are not used.
+the admin_user will be set to blank (disabled).
 */}}
 {{- define "wg-portal.admin" -}}
 {{- $externalAdmin := false -}}
@@ -80,9 +80,8 @@ the admin_user and admin_password values are not used.
     {{- end -}}
   {{- end -}}
 {{- end -}}
-{{- if not $externalAdmin -}}
-admin_user: admin@wgportal.local
-admin_password: {{ printf "%s/%s" .Release.Name .Release.Namespace | b64enc }}
+{{- if $externalAdmin -}}
+admin_user: ""
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -1,3 +1,11 @@
+{{- $advanced := dict "start_listen_port" (.Values.service.wireguard.ports | sortAlpha | first | int) -}}
+{{- $statistics := dict "listening_address" (printf ":%v" .Values.service.metrics.port) -}}
+{{- $web:= dict "listening_address" (printf ":%v" .Values.service.web.port) -}}
+{{- if and .Values.certificate.enabled (include "wg-portal.hostname" .) }}
+  {{- $_ := set $web "cert_file" "/app/certs/tls.crt" }}
+  {{- $_ := set $web "key_file" "/app/certs/tls.key" }}
+{{- end }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,11 +13,9 @@ metadata:
   labels: {{- include "wg-portal.labels" . | nindent 4 }}
 stringData:
   config.yml: |
-    advanced:
-      start_listen_port: {{ .Values.service.wireguard.ports | sortAlpha | first }}
-      {{- with .Values.config.advanced }}
-      {{- tpl (toYaml (omit . "start_listen_port")) $ | nindent 6 }}
-      {{- end }}
+    {{- with mustMerge $advanced .Values.config.advanced }}
+    advanced: {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
 
     {{- with .Values.config.auth }}
     auth: {{- tpl (toYaml .) $ | nindent 6 }}
@@ -27,14 +33,10 @@ stringData:
     mail: {{- tpl (toYaml .) $ | nindent 6 }}
     {{- end }}
 
-    statistics:
-      listening_address: :{{ .Values.service.metrics.port }}
-      {{- with .Values.config.statistics }}
-      {{- tpl (toYaml (omit . "listening_address")) $ | nindent 6 }}
-      {{- end }}
+    {{- with mustMerge $statistics .Values.config.statistics }}
+    statistics: {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}
 
-    web:
-      listening_address: :{{ .Values.service.web.port }}
-      {{- with .Values.config.web }}
-      {{- tpl (toYaml (omit . "listening_address")) $ | nindent 6 }}
-      {{- end }}
+    {{- with mustMerge $web .Values.config.web }}
+    web: {{- tpl (toYaml .) $ | nindent 6 }}
+    {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -15,9 +15,9 @@ config:
   # -- (tpl/object) [Auth configuration](https://wgportal.org/latest/documentation/configuration/overview/#auth) options.
   auth: {}
   # -- (tpl/object) [Core configuration](https://wgportal.org/latest/documentation/configuration/overview/#core) options.<br>
-  # If external admins in `auth` are not defined and
+  # If external admins in `auth` are defined and
   # there are no `admin_user` and `admin_password` defined here,
-  # the default credentials will be generated.
+  # the default admin account will be disabled.
   core: {}
   # -- (tpl/object) [Database configuration](https://wgportal.org/latest/documentation/configuration/overview/#database) options
   database: {}
@@ -150,7 +150,8 @@ ingress:
   tls: false
 
 certificate:
-  # -- Specifies whether a certificate resource should be created
+  # -- Specifies whether a certificate resource should be created.
+  # If enabled, certificate will be used for the web.
   enabled: false
   issuer:
     # -- Certificate issuer name


### PR DESCRIPTION
* Disable admin account if external auth providers has admin groups
* Use created certificate for web.

Signed-off-by: Dmytro Bondar <git@bonddim.dev>
