### PR TITLE
[DOCS] Fix example config wrt. admin_value_regex and admin_group_regex

### DIFF
--- a/docs/documentation/configuration/examples.md
+++ b/docs/documentation/configuration/examples.md
@@ -102,7 +102,7 @@ auth:
         department: department
         is_admin: wg_admin
       admin_mapping:
-        - admin_value_regex: ^true$
+        admin_value_regex: ^true$
       registration_enabled: true
       log_user_info: true
 
@@ -125,7 +125,7 @@ auth:
         department: department
         user_groups: groups
       admin_mapping:
-        - admin_group_regex: ^the-admin-group$
+        admin_group_regex: ^the-admin-group$
       registration_enabled: true
       log_user_info: true
 ```
@@ -157,7 +157,7 @@ auth:
         firstname: name
         is_admin: this-attribute-must-be-true
       admin_mapping:
-        - admin_value_regex: ^(True|true)$
+        admin_value_regex: ^(True|true)$
       registration_enabled: true
     
     # a sample provider where either users with the attribute `this-attribute-must-be-true` set to `true` or 


### PR DESCRIPTION
Before this change, the example config in some places had `admin_value_regex` and `admin_group_regex` as list items under `admin_mapping`, which caused the following error:

```
panic: failed to load config from yaml: yaml error: yaml: unmarshal errors:
  line 45: cannot unmarshal !!seq into config.OauthAdminMapping
```

Removing the list and making them normal YML items prevents this error, as `admin_mapping` does not expect a list.

This also fits my understanding of the [config implementation](https://github.com/h44z/wg-portal/blob/7557a6ef5acb6da4cfda9d24e00078f19fd3dad0/internal/config/auth.go#L32) and another [example config file](https://github.com/h44z/wg-portal/blob/662e9c0549eb68f0df4ba56e43c2c8dcd5bb0969/config.yml.sample#L88).