### PR TITLE
config: Set default mail config to validate TLS certs

### DIFF
--- a/docs/documentation/configuration/overview.md
+++ b/docs/documentation/configuration/overview.md
@@ -58,7 +58,7 @@ mail:
   host: 127.0.0.1
   port: 25
   encryption: none
-  cert_validation: false
+  cert_validation: true
   username: ""
   password: ""
   auth_type: plain
@@ -289,7 +289,7 @@ Options for configuring email notifications or sending peer configurations via e
 - **Description:** SMTP encryption type. Valid values: `none`, `tls`, `starttls`.
 
 ### `cert_validation`
-- **Default:** `false`
+- **Default:** `true`
 - **Description:** If `true`, validate the SMTP server certificate (relevant if `encryption` = `tls`).
 
 ### `username`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,7 +145,7 @@ func defaultConfig() *Config {
 		Host:           "127.0.0.1",
 		Port:           25,
 		Encryption:     MailEncryptionNone,
-		CertValidation: false,
+		CertValidation: true,
 		Username:       "",
 		Password:       "",
 		AuthType:       MailAuthPlain,


### PR DESCRIPTION
## Problem Statement

Before this commit, the default was to not validate TLS certificates of the SMTP server. This is perhaps a rather unexpected default and can be considered insecure.

## Proposed Changes

 This commit activates mail server TLS cert validation by default.

This change might break some users' email configuration, if they did not explicitly set the `mail.cert_validation` config variable. Nonetheless, I think that the secure option should be the default option (e.g., to prevent man-in-the-middle attacks and breaching mail server login credentials).
