### PR TITLE
Enable allowed_domains in oauth and oidc providers

### DIFF
--- a/internal/app/auth/auth.go
+++ b/internal/app/auth/auth.go
@@ -63,6 +63,8 @@ type AuthenticatorOauth interface {
 	ParseUserInfo(raw map[string]any) (*domain.AuthenticatorUserInfo, error)
 	// RegistrationEnabled returns whether registration is enabled for the OAuth authenticator.
 	RegistrationEnabled() bool
+	// GetAllowedDomains returns the list of whitelisted domains
+	GetAllowedDomains() []string
 }
 
 // AuthenticatorLdap is the interface for all LDAP authenticators.
@@ -392,6 +394,24 @@ func (a *Authenticator) randString(nByte int) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
+
+func isDomainAllowed(email string, allowedDomains []string) bool {
+	if len(allowedDomains) < 1 {
+		return true
+	}
+    parts := strings.Split(email, "@")
+    if len(parts) != 2 {
+        return false
+    }
+    domain := strings.ToLower(parts[1])
+    for _, allowed := range allowedDomains {
+        if strings.ToLower(domain) == strings.ToLower(allowed) {
+            return true
+        }
+    }
+    return false
+}
+
 // OauthLoginStep2 finishes the oauth authentication flow by exchanging the code for an access token and
 // fetching the user information.
 func (a *Authenticator) OauthLoginStep2(ctx context.Context, providerId, nonce, code string) (*domain.User, error) {
@@ -429,6 +449,10 @@ func (a *Authenticator) OauthLoginStep2(ctx context.Context, providerId, nonce, 
 			},
 		})
 		return nil, fmt.Errorf("unable to process user information: %w", err)
+	}
+
+	if !isDomainAllowed(userInfo.Email, oauthProvider.GetAllowedDomains()) {
+		return nil, fmt.Errorf("user is not in allowed domains: %w", err)
 	}
 
 	if user.IsLocked() || user.IsDisabled() {

--- a/internal/app/auth/auth.go
+++ b/internal/app/auth/auth.go
@@ -394,22 +394,21 @@ func (a *Authenticator) randString(nByte int) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-
 func isDomainAllowed(email string, allowedDomains []string) bool {
 	if len(allowedDomains) == 0 {
 		return true
 	}
-    parts := strings.Split(email, "@")
-    if len(parts) != 2 {
-        return false
-    }
-    domain := strings.ToLower(parts[1])
-    for _, allowed := range allowedDomains {
-        if domain == strings.ToLower(allowed) {
-            return true
-        }
-    }
-    return false
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		return false
+	}
+	domain := strings.ToLower(parts[1])
+	for _, allowed := range allowedDomains {
+		if domain == strings.ToLower(allowed) {
+			return true
+		}
+	}
+	return false
 }
 
 // OauthLoginStep2 finishes the oauth authentication flow by exchanging the code for an access token and

--- a/internal/app/auth/auth.go
+++ b/internal/app/auth/auth.go
@@ -396,7 +396,7 @@ func (a *Authenticator) randString(nByte int) (string, error) {
 
 
 func isDomainAllowed(email string, allowedDomains []string) bool {
-	if len(allowedDomains) < 1 {
+	if len(allowedDomains) == 0 {
 		return true
 	}
     parts := strings.Split(email, "@")
@@ -405,7 +405,7 @@ func isDomainAllowed(email string, allowedDomains []string) bool {
     }
     domain := strings.ToLower(parts[1])
     for _, allowed := range allowedDomains {
-        if strings.ToLower(domain) == strings.ToLower(allowed) {
+        if domain == strings.ToLower(allowed) {
             return true
         }
     }

--- a/internal/app/auth/auth_oauth.go
+++ b/internal/app/auth/auth_oauth.go
@@ -27,6 +27,7 @@ type PlainOauthAuthenticator struct {
 	userAdminMapping    *config.OauthAdminMapping
 	registrationEnabled bool
 	userInfoLogging     bool
+	allowedDomains      []string
 }
 
 func newPlainOauthAuthenticator(
@@ -56,6 +57,7 @@ func newPlainOauthAuthenticator(
 	provider.userAdminMapping = &cfg.AdminMapping
 	provider.registrationEnabled = cfg.RegistrationEnabled
 	provider.userInfoLogging = cfg.LogUserInfo
+	provider.allowedDomains = cfg.AllowedDomains
 
 	return provider, nil
 }
@@ -63,6 +65,10 @@ func newPlainOauthAuthenticator(
 // GetName returns the name of the OAuth authenticator.
 func (p PlainOauthAuthenticator) GetName() string {
 	return p.name
+}
+
+func (p PlainOauthAuthenticator) GetAllowedDomains() []string {
+	return p.allowedDomains
 }
 
 // RegistrationEnabled returns whether registration is enabled for the OAuth authenticator.

--- a/internal/app/auth/auth_oidc.go
+++ b/internal/app/auth/auth_oidc.go
@@ -24,6 +24,7 @@ type OidcAuthenticator struct {
 	userAdminMapping    *config.OauthAdminMapping
 	registrationEnabled bool
 	userInfoLogging     bool
+	allowedDomains      []string
 }
 
 func newOidcAuthenticator(
@@ -57,6 +58,7 @@ func newOidcAuthenticator(
 	provider.userAdminMapping = &cfg.AdminMapping
 	provider.registrationEnabled = cfg.RegistrationEnabled
 	provider.userInfoLogging = cfg.LogUserInfo
+	provider.allowedDomains = cfg.AllowedDomains
 
 	return provider, nil
 }
@@ -64,6 +66,10 @@ func newOidcAuthenticator(
 // GetName returns the name of the authenticator.
 func (o OidcAuthenticator) GetName() string {
 	return o.name
+}
+
+func (o OidcAuthenticator) GetAllowedDomains() []string {
+	return o.allowedDomains
 }
 
 // RegistrationEnabled returns whether registration is enabled for this authenticator.

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -188,6 +188,9 @@ type OpenIDConnectProvider struct {
 	// ExtraScopes specifies optional requested permissions.
 	ExtraScopes []string `yaml:"extra_scopes"`
 
+	// AllowedDomains defines the list of allowed domains
+	AllowedDomains []string `yaml:"allowed_domains"`
+
 	// FieldMap is used to map the names of the user-info endpoint fields to wg-portal fields
 	FieldMap OauthFields `yaml:"field_map"`
 
@@ -225,6 +228,9 @@ type OAuthProvider struct {
 
 	// Scope specifies optional requested permissions.
 	Scopes []string `yaml:"scopes"`
+
+	// AllowedDomains defines the list of allowed domains
+	AllowedDomains []string `yaml:"allowed_domains"`
 
 	// FieldMap is used to map the names of the user-info endpoint fields to wg-portal fields
 	FieldMap OauthFields `yaml:"field_map"`


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

-

## Proposed Changes

This allows to configure a list of domains of user emails that are allowed to connect to the wg-portal UI using Oauth/OIDC providers.

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
