### PR TITLE
Implement EditableKeys parameter

### DIFF
--- a/internal/app/wireguard/wireguard_peers.go
+++ b/internal/app/wireguard/wireguard_peers.go
@@ -190,7 +190,7 @@ func (m Manager) CreatePeer(ctx context.Context, peer *domain.Peer) (*domain.Pee
 			return nil, fmt.Errorf("failed to prepare peer for interface %s: %w", peer.InterfaceIdentifier, err)
 		}
 
-		preparedPeer.OverwriteUserEditableFields(peer)
+		preparedPeer.OverwriteUserEditableFields(peer, m.cfg)
 
 		peer = preparedPeer
 	}
@@ -278,7 +278,7 @@ func (m Manager) UpdatePeer(ctx context.Context, peer *domain.Peer) (*domain.Pee
 		if err != nil {
 			return nil, fmt.Errorf("unable to load existing peer %s: %w", peer.Identifier, err)
 		}
-		originalPeer.OverwriteUserEditableFields(peer)
+		originalPeer.OverwriteUserEditableFields(peer, m.cfg)
 
 		peer = originalPeer
 	}

--- a/internal/domain/peer.go
+++ b/internal/domain/peer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"github.com/h44z/wg-portal/internal/config"
 
 	"github.com/h44z/wg-portal/internal"
 )
@@ -129,16 +130,18 @@ func (p *Peer) GenerateDisplayName(prefix string) {
 }
 
 // OverwriteUserEditableFields overwrites the user editable fields of the peer with the values from the userPeer
-func (p *Peer) OverwriteUserEditableFields(userPeer *Peer) {
+func (p *Peer) OverwriteUserEditableFields(userPeer *Peer, cfg *config.Config) {
 	p.DisplayName = userPeer.DisplayName
-	p.Interface.PublicKey = userPeer.Interface.PublicKey
-	p.Interface.PrivateKey = userPeer.Interface.PrivateKey
+	if cfg.Core.EditableKeys {
+		p.Interface.PublicKey = userPeer.Interface.PublicKey
+		p.Interface.PrivateKey = userPeer.Interface.PrivateKey
+		p.PresharedKey = userPeer.PresharedKey
+	}
 	p.Interface.Mtu = userPeer.Interface.Mtu
 	p.PersistentKeepalive = userPeer.PersistentKeepalive
 	p.ExpiresAt = userPeer.ExpiresAt
 	p.Disabled = userPeer.Disabled
 	p.DisabledReason = userPeer.DisabledReason
-	p.PresharedKey = userPeer.PresharedKey
 }
 
 type PeerInterfaceConfig struct {

--- a/internal/domain/peer_test.go
+++ b/internal/domain/peer_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/h44z/wg-portal/internal/config"
 )
 
 func TestPeer_IsDisabled(t *testing.T) {
@@ -98,7 +99,7 @@ func TestPeer_OverwriteUserEditableFields(t *testing.T) {
 		DisplayName: "New DisplayName",
 	}
 
-	peer.OverwriteUserEditableFields(userPeer)
+	peer.OverwriteUserEditableFields(userPeer, &config.Config{})
 	assert.Equal(t, "New DisplayName", peer.DisplayName)
 }
 


### PR DESCRIPTION
## Problem Statement

The parameter core.editable_keys currently does nothing

## Related Issue

-

## Proposed Changes

This makes it so when editable_keys is set to false, users can't overwrite pubkey, psk, privkey via UI. It also fixes a bug where a peer created by a non-admin user doesn't work until one updates it (e.g. disable -> enable)

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
