### PR TITLE
add docker to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,8 @@ updates:
       patch:
         update-types:
           - patch
+
+  - package-ecosystem: "docker"
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Problem Statement

In #205 I added alpine as an external dependency, but missed tracking it with dependabot. Alpine 3.19 goes EOL in 4 months, this should at least give some warning.

## Proposed Changes

Add docker tracking to dependabot.

## Checklist

- [ ] Commits are signed with `git commit --signoff`
- [ ] Changes have reasonable test coverage
- [ ] Tests pass with `make test`
- [ ] Helm docs are up-to-date with `make helm-docs`

I'll run through the proper tests and processes soon, so marked as draft for now.
