### PR TITLE
add webhook event for peer state change (#444)

### DIFF
--- a/internal/adapters/metrics.go
+++ b/internal/adapters/metrics.go
@@ -133,5 +133,5 @@ func (m *MetricsServer) UpdatePeerMetrics(peer *domain.Peer, status domain.PeerS
 	}
 	m.peerReceivedBytesTotal.WithLabelValues(labels...).Set(float64(status.BytesReceived))
 	m.peerSendBytesTotal.WithLabelValues(labels...).Set(float64(status.BytesTransmitted))
-	m.peerIsConnected.WithLabelValues(labels...).Set(internal.BoolToFloat64(status.IsConnected()))
+	m.peerIsConnected.WithLabelValues(labels...).Set(internal.BoolToFloat64(status.IsConnected))
 }

--- a/internal/app/api/v0/model/models_peer.go
+++ b/internal/app/api/v0/model/models_peer.go
@@ -198,7 +198,7 @@ func NewPeerStats(enabled bool, src []domain.PeerStatus) *PeerStats {
 
 	for _, srcStat := range src {
 		stats[string(srcStat.PeerId)] = PeerStatData{
-			IsConnected:      srcStat.IsConnected(),
+			IsConnected:      srcStat.IsConnected,
 			IsPingable:       srcStat.IsPingable,
 			LastPing:         srcStat.LastPing,
 			BytesReceived:    srcStat.BytesReceived,

--- a/internal/app/eventbus.go
+++ b/internal/app/eventbus.go
@@ -36,6 +36,7 @@ const TopicPeerDeleted = "peer:deleted"
 const TopicPeerUpdated = "peer:updated"
 const TopicPeerInterfaceUpdated = "peer:interface:updated"
 const TopicPeerIdentifierUpdated = "peer:identifier:updated"
+const TopicPeerStateChanged = "peer:state:changed"
 
 // endregion peer-events
 

--- a/internal/app/webhooks/model.go
+++ b/internal/app/webhooks/model.go
@@ -42,7 +42,9 @@ const (
 type WebhookEvent = string
 
 const (
-	WebhookEventCreate WebhookEvent = "create"
-	WebhookEventUpdate WebhookEvent = "update"
-	WebhookEventDelete WebhookEvent = "delete"
+	WebhookEventCreate     WebhookEvent = "create"
+	WebhookEventUpdate     WebhookEvent = "update"
+	WebhookEventDelete     WebhookEvent = "delete"
+	WebhookEventConnect    WebhookEvent = "connect"
+	WebhookEventDisconnect WebhookEvent = "disconnect"
 )

--- a/internal/domain/statistics.go
+++ b/internal/domain/statistics.go
@@ -3,21 +3,23 @@ package domain
 import "time"
 
 type PeerStatus struct {
-	PeerId    PeerIdentifier `gorm:"primaryKey;column:identifier"`
-	UpdatedAt time.Time      `gorm:"column:updated_at"`
+	PeerId    PeerIdentifier `gorm:"primaryKey;column:identifier" json:"PeerId"`
+	UpdatedAt time.Time      `gorm:"column:updated_at" json:"-"`
 
-	IsPingable bool       `gorm:"column:pingable"`
-	LastPing   *time.Time `gorm:"column:last_ping"`
+	IsConnected bool `gorm:"column:connected" json:"IsConnected"` // indicates if the peer is connected based on the last handshake or ping
 
-	BytesReceived    uint64 `gorm:"column:received"`
-	BytesTransmitted uint64 `gorm:"column:transmitted"`
+	IsPingable bool       `gorm:"column:pingable" json:"IsPingable"`
+	LastPing   *time.Time `gorm:"column:last_ping" json:"LastPing"`
 
-	LastHandshake    *time.Time `gorm:"column:last_handshake"`
-	Endpoint         string     `gorm:"column:endpoint"`
-	LastSessionStart *time.Time `gorm:"column:last_session_start"`
+	BytesReceived    uint64 `gorm:"column:received" json:"BytesReceived"`
+	BytesTransmitted uint64 `gorm:"column:transmitted" json:"BytesTransmitted"`
+
+	LastHandshake    *time.Time `gorm:"column:last_handshake" json:"LastHandshake"`
+	Endpoint         string     `gorm:"column:endpoint" json:"Endpoint"`
+	LastSessionStart *time.Time `gorm:"column:last_session_start" json:"LastSessionStart"`
 }
 
-func (s PeerStatus) IsConnected() bool {
+func (s *PeerStatus) CalcConnected() {
 	oldestHandshakeTime := time.Now().Add(-2 * time.Minute) // if a handshake is older than 2 minutes, the peer is no longer connected
 
 	handshakeValid := false
@@ -25,7 +27,7 @@ func (s PeerStatus) IsConnected() bool {
 		handshakeValid = !s.LastHandshake.Before(oldestHandshakeTime)
 	}
 
-	return s.IsPingable || handshakeValid
+	s.IsConnected = s.IsPingable || handshakeValid
 }
 
 type InterfaceStatus struct {

--- a/internal/domain/statistics_test.go
+++ b/internal/domain/statistics_test.go
@@ -66,8 +66,9 @@ func TestPeerStatus_IsConnected(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.status.IsConnected(); got != tt.want {
-				t.Errorf("IsConnected() = %v, want %v", got, tt.want)
+			tt.status.CalcConnected()
+			if got := tt.status.IsConnected; got != tt.want {
+				t.Errorf("IsConnected = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
new event types: **connect** and **disconnect**

example payload:

```json
{
  "event": "connect",
  "entity": "peer",
  "identifier": "Fb5TaziAs1WrPBjC/MFbWsIelVXvi0hDKZ3YQM9wmU8=",
  "payload": {
    "PeerId": "Fb5TaziAs1WrPBjC/MFbWsIelVXvi0hDKZ3YQM9wmU8=",
    "IsConnected": true,
    "IsPingable": false,
    "LastPing": null,
    "BytesReceived": 1860,
    "BytesTransmitted": 10824,
    "LastHandshake": "2025-06-26T23:04:33.325216659+02:00",
    "Endpoint": "10.55.66.77:33874",
    "LastSessionStart": "2025-06-26T22:50:40.10221606+02:00"
  }
}
```

## Related Issue

Fixes #444 

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
