### PR TITLE
Added more debug logs and reformated

### DIFF
--- a/internal/app/api/core/server.go
+++ b/internal/app/api/core/server.go
@@ -100,6 +100,7 @@ func (s *Server) Run(ctx context.Context, listenAddress string) {
 	srvContext, cancelFn := context.WithCancel(ctx)
 	go func() {
 		var err error
+		slog.Debug("starting server", "certFile", s.cfg.Web.CertFile, "keyFile", s.cfg.Web.KeyFile)
 		if s.cfg.Web.CertFile != "" && s.cfg.Web.KeyFile != "" {
 			err = srv.ListenAndServeTLS(s.cfg.Web.CertFile, s.cfg.Web.KeyFile)
 		} else {

--- a/internal/app/wireguard/statistics.go
+++ b/internal/app/wireguard/statistics.go
@@ -197,6 +197,7 @@ func (c *StatisticsCollector) collectPeerData(ctx context.Context) {
 							p.CalcConnected()
 
 							if wasConnected != p.IsConnected {
+								slog.Debug("peer connection state changed", "peer", peer.Identifier, "connected", p.IsConnected)
 								connectionStateChanged = true
 								newPeerStatus = *p // store new status for event publishing
 							}


### PR DESCRIPTION
## Proposed Changes

How do you like to solve the issue and why?
In the wireguard.go file, I have integrated structured logging using the slog package. A logger instance has been added to the WgRepo struct, and it is initialised in the NewWireGuardRepository constructor. I have added detailed debug and error logging throughout all the methods of the WgRepo. This will trace operations such as creating, retrieving, updating, and deleting WireGuard interfaces and peers, providing better insight into the adapter's behaviour and making it easier to diagnose issues.

In server.go, I added a debug log that records the certificate and key files being used when the web server starts, which will help in troubleshooting TLS configuration.

Finally, in statistics.go, I added a debug log to explicitly report when a peer's connection state changes, improving the visibility of user connectivity events.

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
