### PR TITLE
allow setting the DisplayName property for newly provisioned peers (#507)

### DIFF
--- a/docs/documentation/rest-api/swagger.yaml
+++ b/docs/documentation/rest-api/swagger.yaml
@@ -403,6 +403,12 @@ definitions:
         type: object
     models.ProvisioningRequest:
         properties:
+            DisplayName:
+                description: |-
+                    DisplayName is an optional name for the new peer.
+                    If unset, a default template value (e.g., "API Peer ...") will be assigned.
+                example: API Peer xyz
+                type: string
             InterfaceIdentifier:
                 description: InterfaceIdentifier is the identifier of the WireGuard interface the peer should be linked to.
                 example: wg0

--- a/internal/app/api/core/assets/doc/v0_swagger.json
+++ b/internal/app/api/core/assets/doc/v0_swagger.json
@@ -1781,6 +1781,11 @@
                         "type": "string"
                     }
                 },
+                "Backend": {
+                    "description": "the backend used for this interface e.g., local, mikrotik, ...",
+                    "type": "string",
+                    "example": "local"
+                },
                 "Disabled": {
                     "description": "flag that specifies if the interface is enabled (up) or not (down)",
                     "type": "boolean"
@@ -2249,6 +2254,12 @@
                 "ApiAdminOnly": {
                     "type": "boolean"
                 },
+                "AvailableBackends": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.SettingsBackendNames"
+                    }
+                },
                 "LoginFormVisible": {
                     "type": "boolean"
                 },
@@ -2266,6 +2277,17 @@
                 },
                 "WebAuthnEnabled": {
                     "type": "boolean"
+                }
+            }
+        },
+        "model.SettingsBackendNames": {
+            "type": "object",
+            "properties": {
+                "Id": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/app/api/core/assets/doc/v0_swagger.yaml
+++ b/internal/app/api/core/assets/doc/v0_swagger.yaml
@@ -65,6 +65,10 @@ definitions:
         items:
           type: string
         type: array
+      Backend:
+        description: the backend used for this interface e.g., local, mikrotik, ...
+        example: local
+        type: string
       Disabled:
         description: flag that specifies if the interface is enabled (up) or not (down)
         type: boolean
@@ -381,6 +385,10 @@ definitions:
     properties:
       ApiAdminOnly:
         type: boolean
+      AvailableBackends:
+        items:
+          $ref: '#/definitions/model.SettingsBackendNames'
+        type: array
       LoginFormVisible:
         type: boolean
       MailLinkOnly:
@@ -393,6 +401,13 @@ definitions:
         type: boolean
       WebAuthnEnabled:
         type: boolean
+    type: object
+  model.SettingsBackendNames:
+    properties:
+      Id:
+        type: string
+      Name:
+        type: string
     type: object
   model.User:
     properties:

--- a/internal/app/api/core/assets/doc/v1_swagger.json
+++ b/internal/app/api/core/assets/doc/v1_swagger.json
@@ -2086,6 +2086,11 @@
                 "InterfaceIdentifier"
             ],
             "properties": {
+                "DisplayName": {
+                    "description": "DisplayName is an optional name for the new peer.\nIf unset, a default template value (e.g., \"API Peer ...\") will be assigned.",
+                    "type": "string",
+                    "example": "API Peer xyz"
+                },
                 "InterfaceIdentifier": {
                     "description": "InterfaceIdentifier is the identifier of the WireGuard interface the peer should be linked to.",
                     "type": "string",

--- a/internal/app/api/core/assets/doc/v1_swagger.yaml
+++ b/internal/app/api/core/assets/doc/v1_swagger.yaml
@@ -445,6 +445,12 @@ definitions:
     type: object
   models.ProvisioningRequest:
     properties:
+      DisplayName:
+        description: |-
+          DisplayName is an optional name for the new peer.
+          If unset, a default template value (e.g., "API Peer ...") will be assigned.
+        example: API Peer xyz
+        type: string
       InterfaceIdentifier:
         description: InterfaceIdentifier is the identifier of the WireGuard interface
           the peer should be linked to.

--- a/internal/app/api/v1/backend/provisioning_service.go
+++ b/internal/app/api/v1/backend/provisioning_service.go
@@ -162,7 +162,11 @@ func (p ProvisioningService) NewPeer(ctx context.Context, req models.Provisionin
 	if req.PresharedKey != "" {
 		peer.PresharedKey = domain.PreSharedKey(req.PresharedKey)
 	}
-	peer.GenerateDisplayName("API")
+	if req.DisplayName == "" {
+		peer.GenerateDisplayName("API")
+	} else {
+		peer.DisplayName = req.DisplayName
+	}
 
 	// save new peer
 	peer, err = p.peers.CreatePeer(ctx, peer)

--- a/internal/app/api/v1/models/models_provisioning.go
+++ b/internal/app/api/v1/models/models_provisioning.go
@@ -68,6 +68,10 @@ type ProvisioningRequest struct {
 	// If no user identifier is set, the authenticated user is used.
 	UserIdentifier string `json:"UserIdentifier" example:"uid-1234567"`
 
+	// DisplayName is an optional name for the new peer.
+	// If unset, a default template value (e.g., "API Peer ...") will be assigned.
+	DisplayName string `json:"DisplayName" example:"API Peer xyz" binding:"omitempty"`
+
 	// PublicKey is the optional public key of the peer. If no public key is set, a new key pair is generated.
 	PublicKey string `json:"PublicKey" example:"xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg=" binding:"omitempty,len=44"`
 	// PresharedKey is the optional pre-shared key of the peer. If no pre-shared key is set, a new key is generated.


### PR DESCRIPTION
Fixes #507

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
