### PR TITLE
ensure that LDAP filter values are escaped

### DIFF
--- a/internal/app/auth/auth_ldap.go
+++ b/internal/app/auth/auth_ldap.go
@@ -54,7 +54,7 @@ func (l LdapAuthenticator) PlaintextAuthentication(userId domain.UserIdentifier,
 
 	attrs := []string{"dn"}
 
-	loginFilter := strings.Replace(l.cfg.LoginFilter, "{{login_identifier}}", string(userId), -1)
+	loginFilter := strings.Replace(l.cfg.LoginFilter, "{{login_identifier}}", ldap.EscapeFilter(string(userId)), -1)
 	searchRequest := ldap.NewSearchRequest(
 		l.cfg.BaseDN,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 20, false, // 20 second time limit
@@ -100,7 +100,7 @@ func (l LdapAuthenticator) GetUserInfo(_ context.Context, userId domain.UserIden
 
 	attrs := internal.LdapSearchAttributes(&l.cfg.FieldMap)
 
-	loginFilter := strings.Replace(l.cfg.LoginFilter, "{{login_identifier}}", string(userId), -1)
+	loginFilter := strings.Replace(l.cfg.LoginFilter, "{{login_identifier}}", ldap.EscapeFilter(string(userId)), -1)
 	searchRequest := ldap.NewSearchRequest(
 		l.cfg.BaseDN,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 20, false, // 20 second time limit


### PR DESCRIPTION
## Problem Statement

LDAP filter values should be escaped to avoid invalid syntax, which can lead to failed searches.

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
