### PR TITLE
add user's display-name to peer view (#525)

### DIFF
--- a/frontend/src/helpers/models.js
+++ b/frontend/src/helpers/models.js
@@ -53,6 +53,7 @@ export function freshPeer() {
     Identifier: "",
     DisplayName: "",
     UserIdentifier: "",
+    UserDisplayName: "",
     InterfaceIdentifier: "",
     Disabled: false,
     ExpiresAt: null,

--- a/frontend/src/views/InterfaceView.vue
+++ b/frontend/src/views/InterfaceView.vue
@@ -400,7 +400,7 @@ onMounted(async () => {
             <span v-if="!peer.Disabled && peer.ExpiresAt" class="text-warning" :title="$t('interfaces.peer-expiring') + ' ' +  peer.ExpiresAt"><i class="fas fa-hourglass-end expiring-peer"></i></span>
           </td>
           <td><span v-if="peer.DisplayName" :title="peer.Identifier">{{peer.DisplayName}}</span><span v-else :title="peer.Identifier">{{ $filters.truncate(peer.Identifier, 10)}}</span></td>
-          <td>{{peer.UserIdentifier}}</td>
+          <td><span :title="peer.UserDisplayName">{{peer.UserIdentifier}}</span></td>
           <td>
             <span v-for="ip in peer.Addresses" :key="ip" class="badge bg-light me-1">{{ ip }}</span>
           </td>

--- a/internal/app/api/v0/model/models_peer.go
+++ b/internal/app/api/v0/model/models_peer.go
@@ -43,6 +43,7 @@ type Peer struct {
 	Identifier          string     `json:"Identifier" example:"super_nice_peer"` // peer unique identifier
 	DisplayName         string     `json:"DisplayName"`                          // a nice display name/ description for the peer
 	UserIdentifier      string     `json:"UserIdentifier"`                       // the owner
+	UserDisplayName     string     `json:"UserDisplayName"`                      // the owner display name
 	InterfaceIdentifier string     `json:"InterfaceIdentifier"`                  // the interface id
 	Disabled            bool       `json:"Disabled"`                             // flag that specifies if the peer is enabled (up) or not (down)
 	DisabledReason      string     `json:"DisabledReason"`                       // the reason why the peer has been disabled
@@ -80,7 +81,7 @@ type Peer struct {
 }
 
 func NewPeer(src *domain.Peer) *Peer {
-	return &Peer{
+	p := &Peer{
 		Identifier:          string(src.Identifier),
 		DisplayName:         src.DisplayName,
 		UserIdentifier:      string(src.UserIdentifier),
@@ -111,6 +112,12 @@ func NewPeer(src *domain.Peer) *Peer {
 		PostDown:            ConfigOptionFromDomain(src.Interface.PostDown),
 		Filename:            src.GetConfigFileName(),
 	}
+
+	if src.User != nil {
+		p.UserDisplayName = src.User.DisplayName()
+	}
+
+	return p
 }
 
 func NewPeers(src []domain.Peer) []Peer {

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -185,6 +185,27 @@ func (u *User) CopyCalculatedAttributes(src *User) {
 	u.LinkedPeerCount = src.LinkedPeerCount
 }
 
+// DisplayName returns the display name of the user.
+// The display name is the first and last name, or the email address of the user.
+// If none of these fields are set, the user identifier is returned.
+func (u *User) DisplayName() string {
+	var displayName string
+	switch {
+	case u.Firstname != "" && u.Lastname != "":
+		displayName = fmt.Sprintf("%s %s", u.Firstname, u.Lastname)
+	case u.Firstname != "":
+		displayName = u.Firstname
+	case u.Lastname != "":
+		displayName = u.Lastname
+	case u.Email != "":
+		displayName = u.Email
+	default:
+		displayName = string(u.Identifier)
+	}
+
+	return displayName
+}
+
 // region webauthn
 
 func (u *User) WebAuthnID() []byte {
@@ -209,19 +230,7 @@ func (u *User) WebAuthnName() string {
 }
 
 func (u *User) WebAuthnDisplayName() string {
-	var userName string
-	switch {
-	case u.Firstname != "" && u.Lastname != "":
-		userName = fmt.Sprintf("%s %s", u.Firstname, u.Lastname)
-	case u.Firstname != "":
-		userName = u.Firstname
-	case u.Lastname != "":
-		userName = u.Lastname
-	default:
-		userName = string(u.Identifier)
-	}
-
-	return userName
+	return u.DisplayName()
 }
 
 func (u *User) WebAuthnCredentials() []webauthn.Credential {


### PR DESCRIPTION
## Related Issue

Fixes #525

## Proposed Changes

Display the user’s display name in the peer view when hovering over the user identifier.
The display name should be resolved in the following order:
 - First and last name
 - Email address
 - User identifier (if neither of the above is set)

<img width="690" height="259" alt="2025-09-21_12-36" src="https://github.com/user-attachments/assets/e6805695-b8b5-4ae0-b4ac-41189cdfd239" />


## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
