### PR TITLE
feat: config by environment variables

### DIFF
--- a/docs/documentation/configuration/overview.md
+++ b/docs/documentation/configuration/overview.md
@@ -206,6 +206,8 @@ The current MikroTik backend is in **BETA** and may not support all features.
 
 ### `ignored_local_interfaces`
 - **Default:** *(empty)*
+- **Environment Variable:** `WG_PORTAL_BACKEND_IGNORED_LOCAL_INTERFACES`
+  (comma-separated values)
 - **Description:** A list of interface names to exclude when enumerating local interfaces.
   This is useful if you want to prevent certain interfaces from being imported from the local system.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/a8m/envsubst"
@@ -137,7 +138,8 @@ func defaultConfig() *Config {
 	}
 
 	cfg.Backend = Backend{
-		Default: LocalBackendName, // local backend is the default (using wgcrtl)
+		Default:                LocalBackendName, // local backend is the default (using wgcrtl)
+		IgnoredLocalInterfaces: getEnvStrSlice("WG_PORTAL_BACKEND_IGNORED_LOCAL_INTERFACES", nil),
 		// Most resolconf implementations use "tun." as a prefix for interface names.
 		// But systemd's implementation uses no prefix, for example.
 		LocalResolvconfPrefix: getEnvStr("WG_PORTAL_BACKEND_LOCAL_RESOLVCONF_PREFIX", "tun."),
@@ -262,6 +264,25 @@ func getEnvStr(name, fallback string) string {
 	}
 
 	return fallback
+}
+
+func getEnvStrSlice(name string, fallback []string) []string {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return fallback
+	}
+
+	strParts := strings.Split(v, ",")
+	stringSlice := make([]string, 0, len(strParts))
+
+	for _, s := range strParts {
+		trimmed := strings.TrimSpace(s)
+		if trimmed != "" {
+			stringSlice = append(stringSlice, trimmed)
+		}
+	}
+
+	return stringSlice
 }
 
 func getEnvBool(name string, fallback bool) bool {


### PR DESCRIPTION
Hi, first of all, thank you for creating a great project!

## Problem Statement

It would be very convenient to be able to configure a docker container running wg-portal without having to mount a config file into the container, especially in certain cloud services where tasks are volatile and often completely detached from the machines they live on. In my case I'm using AWS ECS, and it would be more tedious to work with secrets, and to make sure there are config files that can be mounted into the tasks.

## Proposed Changes

I think being able to configure options through environment variables would be very convenient for simpler use cases, and a common feature of dockerized applications.  A problem, as mentioned in #182, is that it doesn't support options that are lists, and in this PR I've left all those options out, thinking that this is better than nothing (and it solves my specific use-case, and I'm sure for others too).

Let me know what you think!

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
