### PR TITLE
feat: introduce "Create Default Peer" flag for interfaces (#513)

### DIFF
--- a/cmd/wg-portal/main.go
+++ b/cmd/wg-portal/main.go
@@ -47,7 +47,7 @@ func main() {
 	rawDb, err := adapters.NewDatabase(cfg.Database)
 	internal.AssertNoError(err)
 
-	database, err := adapters.NewSqlRepository(rawDb)
+	database, err := adapters.NewSqlRepository(rawDb, cfg)
 	internal.AssertNoError(err)
 
 	wireGuard, err := wireguard.NewControllerManager(cfg)

--- a/docs/documentation/configuration/overview.md
+++ b/docs/documentation/configuration/overview.md
@@ -157,12 +157,14 @@ More advanced options are found in the subsequent `Advanced` section.
 ### `create_default_peer`
 - **Default:** `false`
 - **Environment Variable:** `WG_PORTAL_CORE_CREATE_DEFAULT_PEER`
-- **Description:** If a user logs in for the first time with no existing peers, automatically create a new WireGuard peer for **all** server interfaces.
+- **Description:** If a user logs in for the first time with no existing peers, automatically create a new WireGuard peer for all server interfaces where the "Create default peer" flag is set.
+- **Important:** This option is only effective for interfaces where the "Create default peer" flag is set (via the UI).
 
 ### `create_default_peer_on_creation`
 - **Default:** `false`
 - **Environment Variable:** `WG_PORTAL_CORE_CREATE_DEFAULT_PEER_ON_CREATION`
-- **Description:** If an LDAP user is created (e.g., through LDAP sync) and has no peers, automatically create a new WireGuard peer for **all** server interfaces.
+- **Description:** If an LDAP user is created (e.g., through LDAP sync) and has no peers, automatically create a new WireGuard peer for all server interfaces where the "Create default peer" flag is set.
+- **Important:** This option requires [create_default_peer](#create_default_peer) to be enabled.
 
 ### `re_enable_peer_after_user_enable`
 - **Default:** `true`

--- a/frontend/src/components/InterfaceEditModal.vue
+++ b/frontend/src/components/InterfaceEditModal.vue
@@ -83,6 +83,7 @@ watch(() => props.visible, async (newValue, oldValue) => {
           formData.value.Identifier = interfaces.Prepared.Identifier
           formData.value.DisplayName = interfaces.Prepared.DisplayName
           formData.value.Mode = interfaces.Prepared.Mode
+          formData.value.CreateDefaultPeer = interfaces.Prepared.CreateDefaultPeer
           formData.value.Backend = interfaces.Prepared.Backend
 
           formData.value.PublicKey = interfaces.Prepared.PublicKey
@@ -122,6 +123,7 @@ watch(() => props.visible, async (newValue, oldValue) => {
           formData.value.Identifier = selectedInterface.value.Identifier
           formData.value.DisplayName = selectedInterface.value.DisplayName
           formData.value.Mode = selectedInterface.value.Mode
+          formData.value.CreateDefaultPeer = selectedInterface.value.CreateDefaultPeer
           formData.value.Backend = selectedInterface.value.Backend
 
           formData.value.PublicKey = selectedInterface.value.PublicKey
@@ -486,6 +488,10 @@ async function del() {
             <div class="form-check form-switch">
               <input v-model="formData.Disabled" class="form-check-input" type="checkbox">
               <label class="form-check-label">{{ $t('modals.interface-edit.disabled.label') }}</label>
+            </div>
+            <div class="form-check form-switch" v-if="formData.Mode==='server' && settings.Setting('CreateDefaultPeer')">
+              <input v-model="formData.CreateDefaultPeer" class="form-check-input" type="checkbox">
+              <label class="form-check-label">{{ $t('modals.interface-edit.create-default-peer.label') }}</label>
             </div>
             <div class="form-check form-switch" v-if="formData.Backend==='local'">
               <input v-model="formData.SaveConfig" checked="" class="form-check-input" type="checkbox">

--- a/frontend/src/helpers/models.js
+++ b/frontend/src/helpers/models.js
@@ -4,6 +4,7 @@ export function freshInterface() {
     Disabled: false,
     DisplayName: "",
     Identifier: "",
+    CreateDefaultPeer: false,
     Mode: "server",
     Backend: "local",
 

--- a/frontend/src/lang/translations/de.json
+++ b/frontend/src/lang/translations/de.json
@@ -469,6 +469,9 @@
       "disabled": {
         "label": "Schnittstelle deaktiviert"
       },
+      "create-default-peer": {
+        "label": "Peer für neue Benutzer automatisch erstellen"
+      },
       "save-config": {
         "label": "wg-quick Konfiguration automatisch speichern"
       },

--- a/frontend/src/lang/translations/en.json
+++ b/frontend/src/lang/translations/en.json
@@ -469,6 +469,9 @@
       "disabled": {
         "label": "Interface Disabled"
       },
+      "create-default-peer": {
+        "label": "Create default peer for new users"
+      },
       "save-config": {
         "label": "Automatically save wg-quick config"
       },

--- a/internal/app/api/v0/handlers/endpoint_config.go
+++ b/internal/app/api/v0/handlers/endpoint_config.go
@@ -145,6 +145,7 @@ func (e ConfigEndpoint) handleSettingsGet() http.HandlerFunc {
 				MinPasswordLength:         e.cfg.Auth.MinPasswordLength,
 				AvailableBackends:         controllerFn(),
 				LoginFormVisible:          !e.cfg.Auth.HideLoginForm || !hasSocialLogin,
+				CreateDefaultPeer:         e.cfg.Core.CreateDefaultPeer,
 			})
 		}
 	}

--- a/internal/app/api/v0/model/models.go
+++ b/internal/app/api/v0/model/models.go
@@ -14,6 +14,7 @@ type Settings struct {
 	MinPasswordLength         int                    `json:"MinPasswordLength"`
 	AvailableBackends         []SettingsBackendNames `json:"AvailableBackends"`
 	LoginFormVisible          bool                   `json:"LoginFormVisible"`
+	CreateDefaultPeer         bool                   `json:"CreateDefaultPeer"`
 }
 
 type SettingsBackendNames struct {

--- a/internal/app/api/v0/model/models_interface.go
+++ b/internal/app/api/v0/model/models_interface.go
@@ -9,15 +9,16 @@ import (
 )
 
 type Interface struct {
-	Identifier     string `json:"Identifier" example:"wg0"`      // device name, for example: wg0
-	DisplayName    string `json:"DisplayName"`                   // a nice display name/ description for the interface
-	Mode           string `json:"Mode" example:"server"`         // the interface type, either 'server', 'client' or 'any'
-	Backend        string `json:"Backend" example:"local"`       // the backend used for this interface e.g., local, mikrotik, ...
-	PrivateKey     string `json:"PrivateKey" example:"abcdef=="` // private Key of the server interface
-	PublicKey      string `json:"PublicKey" example:"abcdef=="`  // public Key of the server interface
-	Disabled       bool   `json:"Disabled"`                      // flag that specifies if the interface is enabled (up) or not (down)
-	DisabledReason string `json:"DisabledReason"`                // the reason why the interface has been disabled
-	SaveConfig     bool   `json:"SaveConfig"`                    // automatically persist config changes to the wgX.conf file
+	Identifier        string `json:"Identifier" example:"wg0"`      // device name, for example: wg0
+	DisplayName       string `json:"DisplayName"`                   // a nice display name/ description for the interface
+	Mode              string `json:"Mode" example:"server"`         // the interface type, either 'server', 'client' or 'any'
+	Backend           string `json:"Backend" example:"local"`       // the backend used for this interface e.g., local, mikrotik, ...
+	PrivateKey        string `json:"PrivateKey" example:"abcdef=="` // private Key of the server interface
+	PublicKey         string `json:"PublicKey" example:"abcdef=="`  // public Key of the server interface
+	Disabled          bool   `json:"Disabled"`                      // flag that specifies if the interface is enabled (up) or not (down)
+	DisabledReason    string `json:"DisabledReason"`                // the reason why the interface has been disabled
+	SaveConfig        bool   `json:"SaveConfig"`                    // automatically persist config changes to the wgX.conf file
+	CreateDefaultPeer bool   `json:"CreateDefaultPeer"`             // if true, default peers will be created for this interface
 
 	ListenPort   int      `json:"ListenPort"`   // the listening port, for example: 51820
 	Addresses    []string `json:"Addresses"`    // the interface ip addresses
@@ -65,6 +66,7 @@ func NewInterface(src *domain.Interface, peers []domain.Peer) *Interface {
 		Disabled:                   src.IsDisabled(),
 		DisabledReason:             src.DisabledReason,
 		SaveConfig:                 src.SaveConfig,
+		CreateDefaultPeer:          src.CreateDefaultPeer,
 		ListenPort:                 src.ListenPort,
 		Addresses:                  domain.CidrsToStringSlice(src.Addresses),
 		Dns:                        internal.SliceString(src.DnsStr),
@@ -151,6 +153,7 @@ func NewDomainInterface(src *Interface) *domain.Interface {
 		PreDown:                    src.PreDown,
 		PostDown:                   src.PostDown,
 		SaveConfig:                 src.SaveConfig,
+		CreateDefaultPeer:          src.CreateDefaultPeer,
 		DisplayName:                src.DisplayName,
 		Type:                       domain.InterfaceType(src.Mode),
 		Backend:                    domain.InterfaceBackend(src.Backend),

--- a/internal/app/wireguard/wireguard_interfaces.go
+++ b/internal/app/wireguard/wireguard_interfaces.go
@@ -374,6 +374,7 @@ func (m Manager) PrepareInterface(ctx context.Context) (*domain.Interface, error
 		SaveConfig:                 m.cfg.Advanced.ConfigStoragePath != "",
 		DisplayName:                string(id),
 		Type:                       domain.InterfaceTypeServer,
+		CreateDefaultPeer:          m.cfg.Core.CreateDefaultPeer,
 		DriverType:                 "",
 		Disabled:                   nil,
 		DisabledReason:             "",

--- a/internal/app/wireguard/wireguard_peers.go
+++ b/internal/app/wireguard/wireguard_peers.go
@@ -35,6 +35,10 @@ func (m Manager) CreateDefaultPeer(ctx context.Context, userId domain.UserIdenti
 			continue // only create default peers for server interfaces
 		}
 
+		if !iface.CreateDefaultPeer {
+			continue // only create default peers if the interface flag is set
+		}
+
 		peerAlreadyCreated := slices.ContainsFunc(userPeers, func(peer domain.Peer) bool {
 			return peer.InterfaceIdentifier == iface.Identifier
 		})

--- a/internal/domain/interface.go
+++ b/internal/domain/interface.go
@@ -53,12 +53,13 @@ type Interface struct {
 	SaveConfig bool // automatically persist config changes to the wgX.conf file
 
 	// WG Portal specific
-	DisplayName    string           // a nice display name/ description for the interface
-	Type           InterfaceType    // the interface type, either InterfaceTypeServer or InterfaceTypeClient
-	Backend        InterfaceBackend // the backend that is used to manage the interface (wgctrl, mikrotik, ...)
-	DriverType     string           // the interface driver type (linux, software, ...)
-	Disabled       *time.Time       `gorm:"index"` // flag that specifies if the interface is enabled (up) or not (down)
-	DisabledReason string           // the reason why the interface has been disabled
+	DisplayName       string           // a nice display name/ description for the interface
+	Type              InterfaceType    // the interface type, either InterfaceTypeServer or InterfaceTypeClient
+	CreateDefaultPeer bool             // if true, default peers will be created for this interface
+	Backend           InterfaceBackend // the backend that is used to manage the interface (wgctrl, mikrotik, ...)
+	DriverType        string           // the interface driver type (linux, software, ...)
+	Disabled          *time.Time       `gorm:"index"` // flag that specifies if the interface is enabled (up) or not (down)
+	DisabledReason    string           // the reason why the interface has been disabled
 
 	// Default settings for the peer, used for new peers, those settings will be published to ConfigOption options of
 	// the peer config


### PR DESCRIPTION
## Problem Statement

Provide more fine-grained control over default peer creation. Allow specifying interfaces for which no default peer should be created.
The behaviour for existing installations remains unchanged.

<img width="869" height="1289" alt="2026-01-06_00-11" src="https://github.com/user-attachments/assets/2cafadc4-0245-4405-aa2f-bf6fe9f833d7" />


## Related Issue

Fixes #513 


## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
