### PR TITLE
fix: parity of Base64/URL encoding between frontend and backend

### DIFF
--- a/frontend/src/helpers/encoding.js
+++ b/frontend/src/helpers/encoding.js
@@ -1,7 +1,7 @@
 export function base64_url_encode(input) {
   let output = btoa(input)
-  output = output.replace('+', '.')
-  output = output.replace('/', '_')
-  output = output.replace('=', '-')
+  output = output.replaceAll('+', '.')
+  output = output.replaceAll('/', '_')
+  output = output.replaceAll('=', '-')
   return output
 }


### PR DESCRIPTION
## Problem Statement

Inconsistency between frontend and backend with Base64/URL encoding.

## Related Issue

Fixes #609

## Proposed Changes

Make the frontend replace all the special characters, as the backend.

## Checklist

- [X] Commits are signed with `git commit --signoff`
- [ ] Changes have reasonable test coverage
- [ ] Tests pass with `make test`
- [ ] Helm docs are up-to-date with `make helm-docs`
