### PR TITLE
Implement an optional two-factor-like authentication mechanism

### DIFF
--- a/docs/documentation/configuration/overview.md
+++ b/docs/documentation/configuration/overview.md
@@ -44,6 +44,7 @@ advanced:
   route_table_offset: 20000
   api_admin_only: true
   limit_additional_user_peers: 0
+  two_factor_lifetime: 0
 
 database:
   debug: false
@@ -339,6 +340,10 @@ Additional or more specialized configuration options for logging and interface c
 - **Environment Variable:** `WG_PORTAL_ADVANCED_LIMIT_ADDITIONAL_USER_PEERS`
 - **Description:** Limit additional peers a normal user can create. `0` means unlimited.
 
+### `two_factor_lifetime`
+- **Default:** `0`
+- **Environment Variable:** `WG_PORTAL_ADVANCED_TWO_FACTOR_LIFETIME`
+- **Description:** Require a login after the set interval, otherwise the peer will be disabled. `0` disables this feature.
 ---
 
 ## Database

--- a/docs/documentation/usage/authentication.md
+++ b/docs/documentation/usage/authentication.md
@@ -150,3 +150,17 @@ All groups that are listed in the `memberof` attribute of the user will be check
 
 ## User Synchronization
 
+## Two-factor-like authentication
+
+When enabled, this feature requires users to periodically authenticate via the web UI to keep their WireGuard peers active, adding a second verification layer beyond just possessing the WireGuard keys.
+
+To enable this feature, simply set `two_factor_lifetime` parameter in config->advanced (or via WG_PORTAL_ADVANCED_TWO_FACTOR_LIFETIME env variable) to the desired lifetime (0 disables the feature):
+
+```yaml
+advanced:
+  two_factor_lifetime: 12h
+```
+
+The above example will require users to log-out / log-in from WG-portal every 12 hours to keep their peers active.
+
+Note: due to the standalone nature of the Wireguard protocol, I couldn't find a way to communicate to users that their peer has expired. Most tools will consider the connection as "established" even though the remote-peer has been deleted.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -35,6 +35,11 @@ onMounted(async () => {
     }
   }
 
+  if (!wasLoggedIn && window.location.href != '/app/#/login') {
+    window.location.href = '/app/#/login';
+    return
+  }
+
   console.log("WireGuard Portal ready!");
 })
 
@@ -199,14 +204,13 @@ const userDisplayName = computed(() => {
                 <a class="dropdown-item" href="#" @click.prevent="switchLanguage('de')"><span class="fi fi-de"></span> Deutsch</a>
                 <a class="dropdown-item" href="#" @click.prevent="switchLanguage('en')"><span class="fi fi-us"></span> English</a>
                 <a class="dropdown-item" href="#" @click.prevent="switchLanguage('fr')"><span class="fi fi-fr"></span> Français</a>
-  	          	<a class="dropdown-item" href="#" @click.prevent="switchLanguage('ko')"><span class="fi fi-kr"></span> 한국어</a>
+                <a class="dropdown-item" href="#" @click.prevent="switchLanguage('ko')"><span class="fi fi-kr"></span> 한국어</a>
                 <a class="dropdown-item" href="#" @click.prevent="switchLanguage('pt')"><span class="fi fi-pt"></span> Português</a>
                 <a class="dropdown-item" href="#" @click.prevent="switchLanguage('ru')"><span class="fi fi-ru"></span> Русский</a>
                 <a class="dropdown-item" href="#" @click.prevent="switchLanguage('uk')"><span class="fi fi-ua"></span> Українська</a>
                 <a class="dropdown-item" href="#" @click.prevent="switchLanguage('vi')"><span class="fi fi-vi"></span> Tiếng Việt</a>
                 <a class="dropdown-item" href="#" @click.prevent="switchLanguage('zh')"><span class="fi fi-cn"></span> 中文</a>
                 <a class="dropdown-item" href="#" @click.prevent="switchLanguage('es')"><span class="fi fi-es"></span> Español</a>
-                
               </div>
             </div>
           </div>

--- a/internal/app/api/v0/model/models_peer.go
+++ b/internal/app/api/v0/model/models_peer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/h44z/wg-portal/internal/domain"
 )
 
-const ExpiryDateTimeLayout = "\"2006-01-02\""
+const ExpiryDateTimeLayout = "\"2006-01-02T15:04:05\""
 
 type ExpiryDate struct {
 	*time.Time

--- a/internal/app/api/v1/models/models_peer.go
+++ b/internal/app/api/v1/models/models_peer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/h44z/wg-portal/internal/domain"
 )
 
-const ExpiryDateTimeLayout = "2006-01-02"
+const ExpiryDateTimeLayout = "2006-01-02T15:04:05"
 
 // Peer represents a WireGuard peer entry.
 type Peer struct {
@@ -24,7 +24,7 @@ type Peer struct {
 	// DisabledReason is the reason why the peer has been disabled.
 	DisabledReason string `json:"DisabledReason" binding:"required_if=Disabled true" example:"This is a reason why the peer has been disabled."`
 	// ExpiresAt is the expiry date of the peer  in YYYY-MM-DD format. An expired peer is not able to connect.
-	ExpiresAt string `json:"ExpiresAt,omitempty" binding:"omitempty,datetime=2006-01-02"`
+	ExpiresAt string `json:"ExpiresAt,omitempty" binding:"omitempty,datetime=2006-01-02T15:04:05"`
 	// Notes is a note field for peers.
 	Notes string `json:"Notes" example:"This is a note for the peer."`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,8 +43,9 @@ type Config struct {
 		ExpiryCheckInterval      time.Duration `yaml:"expiry_check_interval"`
 		RulePrioOffset           int           `yaml:"rule_prio_offset"`
 		RouteTableOffset         int           `yaml:"route_table_offset"`
-		ApiAdminOnly             bool          `yaml:"api_admin_only"` // if true, only admin users can access the API
+		ApiAdminOnly             bool          `yaml:"api_admin_only"`               // if true, only admin users can access the API
 		LimitAdditionalUserPeers int           `yaml:"limit_additional_user_peers"`
+		TwoFactorLifetime        time.Duration `yaml:"two_factor_lifetime"`          // if set, all peers will expire after duration and require a login into UI
 	} `yaml:"advanced"`
 
 	Backend Backend `yaml:"backend"`
@@ -174,6 +175,7 @@ func defaultConfig() *Config {
 	cfg.Advanced.RouteTableOffset = getEnvInt("WG_PORTAL_ADVANCED_ROUTE_TABLE_OFFSET", 20000)
 	cfg.Advanced.ApiAdminOnly = getEnvBool("WG_PORTAL_ADVANCED_API_ADMIN_ONLY", true)
 	cfg.Advanced.LimitAdditionalUserPeers = getEnvInt("WG_PORTAL_ADVANCED_LIMIT_ADDITIONAL_USER_PEERS", 0)
+	cfg.Advanced.TwoFactorLifetime = getEnvDuration("WG_PORTAL_ADVANCED_TWO_FACTOR_LIFETIME", 0)
 
 	cfg.Statistics.UsePingChecks = getEnvBool("WG_PORTAL_STATISTICS_USE_PING_CHECKS", true)
 	cfg.Statistics.PingCheckWorkers = getEnvInt("WG_PORTAL_STATISTICS_PING_CHECK_WORKERS", 10)

--- a/internal/domain/base.go
+++ b/internal/domain/base.go
@@ -59,6 +59,7 @@ const (
 	DisabledReasonLdapMissing      = "missing in ldap"
 	DisabledReasonMigrationDummy   = "migration dummy user"
 	DisabledReasonInterfaceMissing = "missing WireGuard interface"
+	DisabledReasonPendingActivation = "pending activation"
 
 	LockedReasonAdmin = "locked by admin"
 	LockedReasonApi   = "locked by admin"

--- a/internal/domain/peer.go
+++ b/internal/domain/peer.go
@@ -144,6 +144,10 @@ func (p *Peer) OverwriteUserEditableFields(userPeer *Peer, cfg *config.Config) {
 	p.Interface.Mtu = userPeer.Interface.Mtu
 	p.PersistentKeepalive = userPeer.PersistentKeepalive
 	p.ExpiresAt = userPeer.ExpiresAt
+	if cfg.Advanced.TwoFactorLifetime > time.Duration(0) {
+		t := time.Now().Add(cfg.Advanced.TwoFactorLifetime)
+		p.ExpiresAt = &t
+	}
 	p.Disabled = userPeer.Disabled
 	p.DisabledReason = userPeer.DisabledReason
 }


### PR DESCRIPTION
## Problem Statement

Currently, when a peer key is delivered to the user, it will never expire unless an administrator sets an expiry date manually or disables it. This could become tedious to manage and unfortunately doesn't protect the system whenever a peer key is stolen and reused by a malicious actor.

This feature adds an additional layer, requiring users to re-authenticate to the WG-portal UI (supposedly made public) at regular intervals, guaranteeing that when a peer key is stolen, the malicious actor won't be able to connect after some time unless they are also in possession of the users credentials (either local or LDAP/SSO), and without any manual action from an administrator.

## Related Issue

N/A this is a new feature.

## Proposed Changes

- Implement a new parameter called `two_factor_lifetime`, which controls the time after which the peer expires. In the backend this connects directly into the existing "expiration" mechanism, so that minimal code changes are required
- Also adds a fix to the log-out page redirection, since a complete logout/login cycle must happen to enable the peers.
- Finally, this updates the ExpiryDateTimeLayout to include hours/minutes/seconds, so that the users are shown precise data regarding when their peers will next expire.

## Checklist

- [X] Commits are signed with `git commit --signoff`
- [X] Changes have reasonable test coverage
- [X] Tests pass with `make test`
- [X] Helm docs are up-to-date with `make helm-docs`
