### PR TITLE
fix: ldap user creation when login in

### DIFF
--- a/internal/app/auth/auth.go
+++ b/internal/app/auth/auth.go
@@ -351,7 +351,6 @@ func (a *Authenticator) passwordAuthentication(
 		domain.SystemAdminContextUserInfo()) // switch to admin user context to check if user exists
 
 	var ldapUserInfo *domain.AuthenticatorUserInfo
-	var ldapProvider AuthenticatorLdap
 
 	var userInDatabase = false
 	existingUser, err := a.users.GetUser(ctx, identifier)
@@ -417,14 +416,14 @@ func (a *Authenticator) passwordAuthentication(
 					"source", ldapAuth.GetName(), "identifier", identifier, "error", err)
 				continue
 			}
-			user, err := a.processUserInfo(ctx, ldapUserInfo, domain.UserSourceLdap, ldapProvider.GetName(), true)
+			user, err := a.processUserInfo(ctx, ldapUserInfo, domain.UserSourceLdap, ldapAuth.GetName(), true)
 			if err != nil {
 				return nil, fmt.Errorf("unable to process user information: %w", err)
 			}
 
 			existingUser = user
 			slog.Debug("created new LDAP user in db",
-				"identifier", user.Identifier, "provider", ldapProvider.GetName())
+				"identifier", user.Identifier, "provider", ldapAuth.GetName())
 
 			authOK = true
 			break


### PR DESCRIPTION
## Problem Statement

When login in with ldap, but with the sync disabled the the user is not in the database, the wrong provider variable is used and thus leading to a nil pointer dereference

## Proposed Changes

I changed in the account creation part every occurrence of ldapProvider to ldapAuth, and removed the variable ldapProvider since it wasn't used, and only re-declared in an inner block.

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [ ] Changes have reasonable test coverage 
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`