### PR TITLE
Updated documentation

### DIFF
--- a/docs/documentation/getting-started/docker.md
+++ b/docs/documentation/getting-started/docker.md
@@ -35,6 +35,14 @@ WireGuard Portal supports managing WireGuard interfaces through three distinct d
    > :warning: If host networking is used, the WireGuard Portal UI will be accessible on all the host's IP addresses if the listening address is set to `:8888` in the configuration file.
    To avoid this, you can bind the listening address to a specific IP address, for example, the loopback address (`127.0.0.1:8888`). It is also possible to deploy firewall rules to restrict access to the WireGuard Portal UI.
 
+   > :warning: If the host is running **systemd-networkd**, routes managed by WireGuard Portal may be removed whenever systemd-networkd restarts, as it will clean up routes it considers "foreign". To prevent this, add the following to your host's network configuration (e.g. `/etc/systemd/networkd.conf` or a drop-in file):
+   > ```ini
+   > [Network]
+   > ManageForeignRoutingPolicyRules=no
+   > ManageForeignRoutes=no
+   > ```
+   > After editing, reload the configuration with `sudo systemctl restart systemd-networkd`. For more information refer to the [systemd-networkd documentation](https://www.freedesktop.org/software/systemd/man/latest/networkd.conf.html#ManageForeignRoutes=).
+
  - **Within the WireGuard Portal Docker container**: 
    WireGuard interfaces can be managed directly from within the WireGuard Portal container itself.
    This is the recommended approach when running WireGuard Portal via Docker, as it encapsulates all functionality in a single, portable container without requiring a separate WireGuard host or image.


### PR DESCRIPTION
Include pass about systemd networkd managing foreign routes and deleting them on restart.

## Problem Statement

Running wg-portal in a docker container with network mode = host. On a plain Ubuntu 24.04 server.
However, when unattended-updates decides to install updates and restarts the service systemd-networkd my wireguard peers lose connection and cannot access others in the network.

A restart of the wg-portal container solves the issue as that re-creates the routes.

## Related Issue

Fixes #621 

## Proposed Changes

Explicitly call attention in the documentation for systemd-networkd users

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [ ] Changes have reasonable test coverage
- [ ] Tests pass with `make test`
- [ ] Helm docs are up-to-date with `make helm-docs`
