### PR TITLE
fix: reduce false peer disconnects by widening handshake validity window

### DIFF
--- a/internal/app/wireguard/statistics.go
+++ b/internal/app/wireguard/statistics.go
@@ -258,7 +258,7 @@ func getSessionStartTime(
 		return nil // currently not connected
 	}
 
-	oldestHandshakeTime := time.Now().Add(-2 * time.Minute) // if a handshake is older than 2 minutes, the peer is no longer connected
+	oldestHandshakeTime := time.Now().Add(-domain.HandshakeValidityWindow) // if a handshake is older than the validity window, the peer is no longer connected
 	switch {
 	// old session was never initiated
 	case oldStats.BytesReceived == 0 && oldStats.BytesTransmitted == 0 && (newReceived > 0 || newTransmitted > 0):

--- a/internal/app/wireguard/statistics_test.go
+++ b/internal/app/wireguard/statistics_test.go
@@ -11,7 +11,7 @@ import (
 func Test_getSessionStartTime(t *testing.T) {
 	now := time.Now()
 	nowMinus1 := now.Add(-1 * time.Minute)
-	nowMinus3 := now.Add(-3 * time.Minute)
+	nowMinus4 := now.Add(-4 * time.Minute)
 	nowMinus5 := now.Add(-5 * time.Minute)
 
 	type args struct {
@@ -84,7 +84,7 @@ func Test_getSessionStartTime(t *testing.T) {
 				},
 				newReceived:    100,
 				newTransmitted: 100,
-				lastHandshake:  &nowMinus3,
+				lastHandshake:  &nowMinus4,
 			},
 			want: &nowMinus5,
 		},

--- a/internal/domain/statistics.go
+++ b/internal/domain/statistics.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+const HandshakeValidityWindow = 3 * time.Minute
+
 type PeerStatus struct {
 	PeerId    PeerIdentifier `gorm:"primaryKey;column:identifier" json:"PeerId"`
 	UpdatedAt time.Time      `gorm:"column:updated_at" json:"-"`
@@ -22,7 +24,7 @@ type PeerStatus struct {
 }
 
 func (s *PeerStatus) CalcConnected() {
-	oldestHandshakeTime := time.Now().Add(-2 * time.Minute) // if a handshake is older than 2 minutes, the peer is no longer connected
+	oldestHandshakeTime := time.Now().Add(-HandshakeValidityWindow) // if a handshake is older than the validity window, the peer is no longer connected
 
 	handshakeValid := false
 	if s.LastHandshake != nil {

--- a/internal/domain/statistics_test.go
+++ b/internal/domain/statistics_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestPeerStatus_IsConnected(t *testing.T) {
 	now := time.Now()
-	past := now.Add(-3 * time.Minute)
+	past := now.Add(-4 * time.Minute)
 	recent := now.Add(-1 * time.Minute)
 
 	tests := []struct {


### PR DESCRIPTION
## Bug
Fixes #641 — the connection checks treated handshakes older than 2 minutes as disconnected. In practice, healthy idle peers can exceed that interval and trigger false disconnect/connect webhook flaps.

## Fix
- Introduced a shared handshake validity window constant set to 3 minutes
- Reused that window in both peer connectivity calculation and session restart detection
- Updated related tests to reflect the widened timeout window

## Testing
- `go test ./internal/domain`
- `go test ./internal/app/wireguard` cannot run in this macOS environment because the package depends on Linux netlink symbols; the touched logic is covered by updated unit tests

Happy to address any feedback.

Greetings, saschabuehrle