### PR TITLE
feat(metrics): add user label to peer metrics

### DIFF
--- a/internal/adapters/metrics.go
+++ b/internal/adapters/metrics.go
@@ -30,7 +30,7 @@ type MetricsServer struct {
 // Wireguard metrics labels
 var (
 	ifaceLabels = []string{"interface"}
-	peerLabels  = []string{"interface", "addresses", "id", "name"}
+	peerLabels  = []string{"interface", "addresses", "id", "name", "user"}
 )
 
 // NewMetricsServer returns a new prometheus server
@@ -126,6 +126,7 @@ func (m *MetricsServer) UpdatePeerMetrics(peer *domain.Peer, status domain.PeerS
 		peer.Interface.AddressStr(),
 		string(status.PeerId),
 		peer.DisplayName,
+		string(peer.UserIdentifier),
 	}
 
 	if status.LastHandshake != nil {


### PR DESCRIPTION
## Problem Statement

In my setup users can edit their peers, so peer name as a label in Prometheus metric is not valuable as a username from SSO (OpenID) provider

## Related Issue

#646

## Proposed Changes
add "user" label to Prometheus metrics


## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
