### PR TITLE
fix: prevent interface address clearing during startup

### DIFF
--- a/internal/adapters/database.go
+++ b/internal/adapters/database.go
@@ -482,7 +482,7 @@ func (r *SqlRepo) getOrCreateInterface(
 		Identifier: id,
 	}
 
-	err := tx.Attrs(interfaceDefaults).FirstOrCreate(&in, id).Error
+	err := tx.Preload("Addresses").Attrs(interfaceDefaults).FirstOrCreate(&in, id).Error
 	if err != nil {
 		return nil, err
 	}
@@ -691,7 +691,7 @@ func (r *SqlRepo) getOrCreatePeer(ui *domain.ContextUserInfo, tx *gorm.DB, id do
 		Identifier: id,
 	}
 
-	err := tx.Attrs(interfaceDefaults).FirstOrCreate(&peer, id).Error
+	err := tx.Preload("Addresses").Attrs(interfaceDefaults).FirstOrCreate(&peer, id).Error
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapters/database_simple_test.go
+++ b/internal/adapters/database_simple_test.go
@@ -1,0 +1,73 @@
+package adapters
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/h44z/wg-portal/internal/config"
+	"github.com/h44z/wg-portal/internal/domain"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+func init() {
+	schema.RegisterSerializer("encstr", dummySerializer{})
+}
+
+type dummySerializer struct{}
+
+func (dummySerializer) Scan(ctx context.Context, field *schema.Field, dst reflect.Value, dbValue any) error {
+	return nil
+}
+
+func (dummySerializer) Value(ctx context.Context, field *schema.Field, dst reflect.Value, fieldValue any) (any, error) {
+	if fieldValue == nil {
+		return nil, nil
+	}
+	if v, ok := fieldValue.(string); ok {
+		return v, nil
+	}
+	if v, ok := fieldValue.(domain.PreSharedKey); ok {
+		return string(v), nil
+	}
+	return fieldValue, nil
+}
+
+func TestSqlRepo_SaveInterface_Simple(t *testing.T) {
+	// Initialize in-memory database
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// Migrate only what's needed for this test (avoids Peer and its encstr serializer)
+	require.NoError(t, db.AutoMigrate(&domain.Interface{}, &domain.Cidr{}))
+
+	repo := &SqlRepo{db: db, cfg: &config.Config{}}
+	ctx := domain.SetUserInfo(context.Background(), domain.SystemAdminContextUserInfo())
+	ifaceId := domain.InterfaceIdentifier("wg0")
+
+	// 1. Create an interface with one address
+	addr, _ := domain.CidrFromString("10.0.0.1/24")
+	initialIface := &domain.Interface{
+		Identifier: ifaceId,
+		Addresses:  []domain.Cidr{addr},
+	}
+	require.NoError(t, db.Create(initialIface).Error)
+
+	// 2. Perform a "partial" update using SaveInterface (this is the buggy path)
+	err = repo.SaveInterface(ctx, ifaceId, func(in *domain.Interface) (*domain.Interface, error) {
+		in.DisplayName = "New Name"
+		return in, nil
+	})
+	require.NoError(t, err)
+
+	// 3. Verify that the address was NOT deleted
+	var finalIface domain.Interface
+	require.NoError(t, db.Preload("Addresses").First(&finalIface, "identifier = ?", ifaceId).Error)
+	
+	require.Equal(t, "New Name", finalIface.DisplayName)
+	require.Len(t, finalIface.Addresses, 1, "Address list should still have 1 entry!")
+	require.Equal(t, "10.0.0.1/24", finalIface.Addresses[0].Cidr)
+}


### PR DESCRIPTION
## Problem Statement

When `wg-portal` (v2.2.2) starts up, it clears the `interface_addresses` table in the database for existing interfaces. This primarily happens when an interface is "restored" but doesn't exist in the kernel yet (e.g., at boot). The application tries to temporarily disable the interface, but the db logic fetches the record without its IP addresses. When saving this record back, GORM interprets the empty address list as a request to delete all associations, thus wiping the addresses from the DB.

## Related Issue

I haven't found a related issue and haven't opened one before working on this.

## Proposed Changes

The `SqlRepo.SaveInterface` and `SqlRepo.SavePeer` methods in `internal/adapters/database.go` have been updated to always preload the `Adresses` many-to-many association before calling the provided update function. This ensures that the existing addresses are preserved even if the update function doesn't explicitly modify them.

## Verification

A regression test has been added in `internal/adapters/database_simple_test.go`. The test confirms the fix:

1. Without Fix: The test fails with `Error:          "[]" should have 1 item(s), but has 0` (proving data loss).
2. With Fix: The test passes successfully (proving data preservation).

```
go test -v ./internal/adapters -run TestSqlRepo_SaveInterface_Simple
```

Also, this change fixes this issue in my productive environment where it first occurred for me.

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
