### PR TITLE
fix: "created_at" for users

### DIFF
--- a/internal/adapters/database.go
+++ b/internal/adapters/database.go
@@ -232,21 +232,19 @@ func (r *SqlRepo) migrate() error {
 	slog.Debug("running migration: interface status", "result", r.db.AutoMigrate(&domain.InterfaceStatus{}))
 	slog.Debug("running migration: audit data", "result", r.db.AutoMigrate(&domain.AuditEntry{}))
 
-	existingSysStat := SysStat{}
+	var existingSysStat SysStat
+	var err error
+
 	r.db.Order("schema_version desc").First(&existingSysStat) // get latest version
 
 	// Migration: 0 --> 1
 	if existingSysStat.SchemaVersion == 0 {
 		const schemaVersion = 1
-		sysStat := SysStat{
-			MigratedAt:    time.Now(),
-			SchemaVersion: schemaVersion,
-		}
-		if err := r.db.Create(&sysStat).Error; err != nil {
-			return fmt.Errorf("failed to write sysstat entry for schema version %d: %w", schemaVersion, err)
+		existingSysStat, err = r.addMigration(schemaVersion) // ensure that follow-up checks test against the latest version
+		if err != nil {
+			return err
 		}
 		slog.Debug("sys-stat entry written", "schema_version", schemaVersion)
-		existingSysStat = sysStat // ensure that follow-up checks test against the latest version
 	}
 
 	// Migration: 1 --> 2
@@ -262,14 +260,10 @@ func (r *SqlRepo) migrate() error {
 			}
 			slog.Debug("migrated interface create_default_peer flags", "schema_version", schemaVersion)
 		}
-		sysStat := SysStat{
-			MigratedAt:    time.Now(),
-			SchemaVersion: schemaVersion,
+		existingSysStat, err = r.addMigration(schemaVersion) // ensure that follow-up checks test against the latest version
+		if err != nil {
+			return err
 		}
-		if err := r.db.Create(&sysStat).Error; err != nil {
-			return fmt.Errorf("failed to write sysstat entry for schema version %d: %w", schemaVersion, err)
-		}
-		existingSysStat = sysStat // ensure that follow-up checks test against the latest version
 	}
 
 	// Migration: 2 --> 3
@@ -307,42 +301,43 @@ func (r *SqlRepo) migrate() error {
 		if err != nil {
 			return fmt.Errorf("failed to migrate to multi-auth: %w", err)
 		}
-		sysStat := SysStat{
-			MigratedAt:    time.Now(),
-			SchemaVersion: schemaVersion,
+		existingSysStat, err = r.addMigration(schemaVersion) // ensure that follow-up checks test against the latest version
+		if err != nil {
+			return err
 		}
-		if err := r.db.Create(&sysStat).Error; err != nil {
-			return fmt.Errorf("failed to write sysstat entry for schema version %d: %w", schemaVersion, err)
-		}
-		existingSysStat = sysStat // ensure that follow-up checks test against the latest version
 	}
 
 	// Migration: 3 --> 4
 	if existingSysStat.SchemaVersion == 3 {
 		const schemaVersion = 4
-		// Fix zero created_at timestamps across all tables
-		for _, table := range []string{"users", "user_authentications", "interfaces", "peers", "audit_entries"} {
-			err := r.db.Exec(
-				"UPDATE "+table+" SET created_at = updated_at WHERE created_at < ?",
-				time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
-			).Error
-			if err != nil {
-				slog.Warn("failed to fix zero created_at in table", "table", table, "error", err)
-			}
-		}
-		slog.Debug("fixed zero created_at timestamps", "schema_version", schemaVersion)
+		cutoff := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 
-		sysStat := SysStat{
-			MigratedAt:    time.Now(),
-			SchemaVersion: schemaVersion,
+		// Fix zero created_at timestamps for users. Set the to the last known update timestamp.
+		err := r.db.Model(&domain.User{}).Where("created_at < ?", cutoff).
+			Update("created_at", gorm.Expr("updated_at")).Error
+		if err != nil {
+			slog.Warn("failed to fix zero created_at for users", "error", err)
 		}
-		if err := r.db.Create(&sysStat).Error; err != nil {
-			return fmt.Errorf("failed to write sysstat entry for schema version %d: %w", schemaVersion, err)
+		slog.Debug("fixed zero created_at timestamps for users", "schema_version", schemaVersion)
+
+		existingSysStat, err = r.addMigration(schemaVersion) // ensure that follow-up checks test against the latest version
+		if err != nil {
+			return err
 		}
-		existingSysStat = sysStat // ensure that follow-up checks test against the latest version
 	}
 
 	return nil
+}
+
+func (r *SqlRepo) addMigration(schemaVersion uint64) (SysStat, error) {
+	sysStat := SysStat{
+		MigratedAt:    time.Now(),
+		SchemaVersion: schemaVersion,
+	}
+	if err := r.db.Create(&sysStat).Error; err != nil {
+		return SysStat{}, fmt.Errorf("failed to write sysstat entry for schema version %d: %w", schemaVersion, err)
+	}
+	return sysStat, nil
 }
 
 // region interfaces
@@ -1021,13 +1016,6 @@ func (r *SqlRepo) getOrCreateUser(ui *domain.ContextUserInfo, tx *gorm.DB, id do
 func (r *SqlRepo) upsertUser(ui *domain.ContextUserInfo, tx *gorm.DB, user *domain.User) error {
 	user.UpdatedBy = ui.UserId()
 	user.UpdatedAt = time.Now()
-
-	if user.CreatedAt.IsZero() {
-		user.CreatedAt = user.UpdatedAt
-	}
-	if user.CreatedBy == "" {
-		user.CreatedBy = ui.UserId()
-	}
 
 	err := tx.Save(user).Error
 	if err != nil {

--- a/internal/adapters/database_created_at_test.go
+++ b/internal/adapters/database_created_at_test.go
@@ -6,11 +6,12 @@ import (
 	"time"
 
 	"github.com/glebarez/sqlite"
-	"github.com/h44z/wg-portal/internal/config"
-	"github.com/h44z/wg-portal/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
+
+	"github.com/h44z/wg-portal/internal/config"
+	"github.com/h44z/wg-portal/internal/domain"
 )
 
 func newTestDB(t *testing.T) *gorm.DB {
@@ -37,8 +38,9 @@ func TestUpsertUser_SetsCreatedAtWhenZero(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.False(t, user.CreatedAt.IsZero(), "CreatedAt should be set when it was zero")
-	assert.Equal(t, ui.UserId(), user.CreatedBy, "CreatedBy should be set when it was empty")
-	assert.WithinDuration(t, user.UpdatedAt, user.CreatedAt, time.Second, "CreatedAt should be close to UpdatedAt for new user")
+	assert.Equal(t, ui.UserId(), user.UpdatedBy, "UpdatedBy should be set when it was empty")
+	assert.WithinDuration(t, user.UpdatedAt, user.CreatedAt, time.Second,
+		"CreatedAt should be close to UpdatedAt for new user")
 }
 
 func TestUpsertUser_PreservesExistingCreatedAt(t *testing.T) {

--- a/internal/app/users/user_manager.go
+++ b/internal/app/users/user_manager.go
@@ -533,6 +533,7 @@ func (m Manager) create(ctx context.Context, user *domain.User) (*domain.User, e
 	}
 
 	err = m.users.SaveUser(ctx, user.Identifier, func(u *domain.User) (*domain.User, error) {
+		user.CopyCalculatedAttributes(u, false)
 		return user, nil
 	})
 	if err != nil {

--- a/internal/domain/base.go
+++ b/internal/domain/base.go
@@ -9,8 +9,8 @@ import (
 type BaseModel struct {
 	CreatedBy string
 	UpdatedBy string
-	CreatedAt time.Time `gorm:"autoCreateTime"`
-	UpdatedAt time.Time `gorm:"autoUpdateTime"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 type PrivateString string


### PR DESCRIPTION
## Problem Statement

The `created_at` field is always stored as a zero timestamp (`0001-01-01 00:00:00`) for users and other entities. This is caused by missing GORM auto-timestamp tags on `BaseModel` and the `upsertUser` function not initializing `CreatedAt`/`CreatedBy` for new records.

## Related Issue

Fixes #655

## Proposed Changes

1. **`internal/domain/base.go`** — Added `gorm:"autoCreateTime"` and `gorm:"autoUpdateTime"` tags to `BaseModel.CreatedAt` and `BaseModel.UpdatedAt` so GORM automatically populates timestamps on insert/update.

2. **`internal/adapters/database.go`** — Two changes:
   - `upsertUser`: Added guards to set `CreatedAt` and `CreatedBy` when they are zero/empty, preventing new users from being saved with missing creation metadata.
   - `migrate`: Added schema migration (v3 → v4) that backfills zero `created_at` values with `updated_at` across all affected tables (`users`, `user_authentications`, `interfaces`, `peers`, `audit_entries`).

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
