### PR TITLE
Add test-in-docker target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test: test-vet test-race
 #> test-in-docker: Run tests in Docker (for non-Linux environments e.g. MacOS)
 .PHONY: test-in-docker
 test-in-docker:
-	/usr/local/bin/docker run --rm -u $(shell id -u):$(shell id -g) -e HOME=/tmp -v $(PWD):/app -w /app golang:$(GOVERSION) make test
+	docker run --rm -u $(shell id -u):$(shell id -g) -e HOME=/tmp -v $(PWD):/app -w /app golang:$(GOVERSION) make test
 
 #< test-vet: Static code analysis
 .PHONY: test-vet


### PR DESCRIPTION
## Problem Statement

fix issue with `make test` on MacOS

```
internal/lowlevel/netlink.go:57:50: undefined: netlink.FAMILY_V4
internal/lowlevel/netlink.go:62:50: undefined: netlink.FAMILY_V6
internal/lowlevel/netlink.go:99:17: undefined: netlink.RuleAdd
internal/lowlevel/netlink.go:103:17: undefined: netlink.RuleDel
internal/lowlevel/netlink.go:107:17: undefined: netlink.RuleList
make: *** [test-vet] Error 1
```


## Related Issue

Fixes #658 

## Proposed Changes

Add a option `test-in-docker` to Makefile  to run tests in Docker for non-Linux environments.

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test-in-docker`
- [x] Helm docs are up-to-date with `make helm-docs`
