### PR TITLE
feat(docs): how to troubleshoot admin_group_regex with oidc

### DIFF
--- a/docs/documentation/configuration/overview.md
+++ b/docs/documentation/configuration/overview.md
@@ -602,6 +602,7 @@ Below are the properties for each OIDC provider entry inside `auth.oidc`:
 - **Description:** WgPortal can grant a user admin rights by matching the value of the `is_admin` claim against a regular expression. Alternatively, a regular expression can be used to check if a user is member of a specific group listed in the `user_group` claim. The regular expressions are defined in `admin_value_regex` and `admin_group_regex`.
     - `admin_value_regex`: A regular expression to match the `is_admin` claim. By default, this expression matches the string "true" (`^true$`).
     - `admin_group_regex`: A regular expression to match the `user_groups` claim. Each entry in the `user_groups` claim is checked against this regex.
+        - To identify which claim to match against, set log_level: debug and reload the config. Log in with the intended admin account and inspect the logs for the OIDC user info payload. If the required claim is missing it must be added by the OIDC provider. If it is present, use its value as the pattern for admin_group_regex.
 
 #### `registration_enabled`
 - **Default:** `false`


### PR DESCRIPTION
Updated docs for identifying claims in OIDC user info payload for admin rights.

## Problem Statement

When setting up Azure it was not clear how to validate what wg-portal sees when logging in using OIDC, making troubleshooting tricky. Specifying to use debug as the detail is visible there.


## Proposed Changes

Update the documentation with a general solution for any oidc provider.

