### PR TITLE
Document necessary systemd-networkd configuration

### DIFF
--- a/docs/documentation/getting-started/binaries.md
+++ b/docs/documentation/getting-started/binaries.md
@@ -51,12 +51,30 @@ sudo install wg-portal /opt/wg-portal/
 To handle tasks such as restarting the service or configuring automatic startup, it is recommended to use a process manager like [systemd](https://systemd.io/). 
 Refer to [Systemd Service Setup](#systemd-service-setup) for instructions.
 
-## Systemd Service Setup
+## Systemd Integration
 
 > **Note:** To run WireGuard Portal as systemd service, you need to download the binary for your architecture beforehand.
 > 
 > The following examples assume that you downloaded the binary to `/opt/wg-portal/wg-portal`. 
 > The configuration file is expected to be located at `/opt/wg-portal/config.yml`.
+
+### Limit Systemd-Networkd Management Scope
+
+If you are using `systemd-networkd` to manage the rest of your network
+configuration, you will need to ensure it doesn't remove routing policy
+created by `wg-portal` when it restarts:
+
+```shell
+sudo mkdir --parents /etc/systemd/networkd.conf.d/
+sudo tee --append /etc/systemd/networkd.conf.d/foreign-routing.conf <<EOF
+[Network]
+ManageForeignRoutingPolicyRules=no
+EOF
+sudo systemctl restart systemd-networkd.service
+sudo systemctl status systemd-networkd.service
+```
+
+### Wireguard Portal Service Setup
 
 To run WireGuard Portal as a systemd service, you can create a service unit file. The easiest way to do this is by using `systemctl edit`:
 


### PR DESCRIPTION
## Problem Statement

By default, the systemd-networkd.service(8) removes routing policy created by other tools when it starts. This can cause wireguard tunnels to stop working during a system upgrade or other administration actions.

## Proposed Changes

Document the configuration necessary to prevent this from occurring.

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [ ] Changes have reasonable test coverage
- [ ] Tests pass with `make test`
- [ ] Helm docs are up-to-date with `make helm-docs`
