### PR TITLE
Fix single-peer interface import mode

### DIFF
--- a/internal/app/wireguard/wireguard_interfaces.go
+++ b/internal/app/wireguard/wireguard_interfaces.go
@@ -893,16 +893,7 @@ func (m Manager) importInterface(
 		}
 	}
 
-	// try to predict the interface type based on the number of peers
-	switch len(peers) {
-	case 0:
-		iface.Type = domain.InterfaceTypeAny // no peers means this is an unknown interface
-	case 1:
-		iface.Type = domain.InterfaceTypeClient // one peer means this is a client interface
-	default: // multiple peers means this is a server interface
-
-		iface.Type = domain.InterfaceTypeServer
-	}
+	iface.Type = inferImportedInterfaceType(iface, peers)
 
 	existingInterface, err := m.db.GetInterface(ctx, iface.Identifier)
 	if err != nil && !errors.Is(err, domain.ErrNotFound) {
@@ -928,6 +919,20 @@ func (m Manager) importInterface(
 	}
 
 	return nil
+}
+
+func inferImportedInterfaceType(iface *domain.Interface, peers []domain.PhysicalPeer) domain.InterfaceType {
+	switch len(peers) {
+	case 0:
+		return domain.InterfaceTypeAny // no peers means this is an unknown interface
+	case 1:
+		if iface.ListenPort > 0 {
+			return domain.InterfaceTypeServer // a listening interface with one peer is commonly a site-to-site server
+		}
+		return domain.InterfaceTypeClient
+	default: // multiple peers means this is a server interface
+		return domain.InterfaceTypeServer
+	}
 }
 
 // extractPfsenseDefaultsFromPeers extracts common endpoint and DNS information from peers

--- a/internal/app/wireguard/wireguard_interfaces_test.go
+++ b/internal/app/wireguard/wireguard_interfaces_test.go
@@ -10,6 +10,49 @@ import (
 	"github.com/h44z/wg-portal/internal/domain"
 )
 
+func TestInferImportedInterfaceType(t *testing.T) {
+	tests := []struct {
+		name       string
+		listenPort int
+		peerCount  int
+		expected   domain.InterfaceType
+	}{
+		{
+			name:       "no peers stays unknown",
+			listenPort: 51820,
+			peerCount:  0,
+			expected:   domain.InterfaceTypeAny,
+		},
+		{
+			name:       "single peer with listen port is server",
+			listenPort: 51820,
+			peerCount:  1,
+			expected:   domain.InterfaceTypeServer,
+		},
+		{
+			name:       "single peer without listen port stays client",
+			listenPort: 0,
+			peerCount:  1,
+			expected:   domain.InterfaceTypeClient,
+		},
+		{
+			name:       "multiple peers is server",
+			listenPort: 0,
+			peerCount:  2,
+			expected:   domain.InterfaceTypeServer,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iface := &domain.Interface{ListenPort: tt.listenPort}
+			peers := make([]domain.PhysicalPeer, tt.peerCount)
+
+			assert.Equal(t, tt.expected, inferImportedInterfaceType(iface, peers))
+		})
+	}
+}
+
 func TestImportPeer_AddressMapping(t *testing.T) {
 	tests := []struct {
 		name                 string


### PR DESCRIPTION
Single-peer WireGuard interfaces are currently imported as client mode unconditionally. That misclassifies site-to-site server topologies that expose a ListenPort but only have one peer.

This changes the import heuristic to keep the existing behavior for 0 peers and 2+ peers, but treats the 1-peer case as server when the imported interface has a ListenPort.

Why:
- a listening interface with one peer is a valid server/site-to-site topology
- importing it as client flips peer/interface roles incorrectly
- the wrong mode can trigger invalid route management on startup

Validation:
- go test ./internal/app/wireguard -run TestInferImportedInterfaceType -count=1
- go test ./internal/app/wireguard -count=1
