### PR TITLE
Fix vue assets under web base path

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
-    "build-dev": "vite build --mode development --base=/app/",
-    "build": "vite build --base=/app/",
+    "build-dev": "vite build --mode development",
+    "build": "vite build",
     "preview": "vite preview --port 5050"
   },
   "dependencies": {

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -5,6 +5,7 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [vue()],
   resolve: {
     alias: {

--- a/internal/app/api/core/server.go
+++ b/internal/app/api/core/server.go
@@ -283,10 +283,13 @@ func (s *Server) updateBasePathInFrontend(useEmbeddedFrontend bool) ([]byte, []b
 	} else {
 		customIndexFile, _ = os.ReadFile(filepath.Join(s.cfg.Web.FrontendFilePath, "index.html"))
 	}
-	newIndexStr := strings.ReplaceAll(string(customIndexFile), "src=\"/", "src=\""+s.cfg.Web.BasePath+"/")
-	newIndexStr = strings.ReplaceAll(newIndexStr, "href=\"/", "href=\""+s.cfg.Web.BasePath+"/")
+	// rewrite relative paths
+	newIndexStr := strings.ReplaceAll(string(customIndexFile), "src=\"./", "src=\""+s.cfg.Web.BasePath+"/app/")
+	newIndexStr = strings.ReplaceAll(newIndexStr, "href=\"./", "href=\""+s.cfg.Web.BasePath+"/app/")
+	// rewrite absolute paths (api calls)
+	newIndexStr = strings.ReplaceAll(newIndexStr, "src=\"/api/", "src=\""+s.cfg.Web.BasePath+"/api/")
 
-	re := regexp.MustCompile(`/app/assets/(index-.+.css)`)
+	re := regexp.MustCompile(`assets/(index-.+.css)`)
 	match := re.FindStringSubmatch(newIndexStr)
 	cssFileName := match[1]
 
@@ -296,7 +299,7 @@ func (s *Server) updateBasePathInFrontend(useEmbeddedFrontend bool) ([]byte, []b
 	} else {
 		customCssFile, _ = os.ReadFile(filepath.Join(s.cfg.Web.FrontendFilePath, "/assets/", cssFileName))
 	}
-	newCssStr := strings.ReplaceAll(string(customCssFile), "/app/assets/", s.cfg.Web.BasePath+"/app/assets/")
+	newCssStr := strings.ReplaceAll(string(customCssFile), "./assets/", s.cfg.Web.BasePath+"/app/assets/")
 
 	return []byte(newIndexStr), []byte(newCssStr), cssFileName
 }


### PR DESCRIPTION
## Problem Statement

Frontend assets not loading when specifying a base path

## Related Issue

Fixes #710

## Proposed Changes

Remove hardcoded `--base=/app/` from npm build script and set `base: './'` in vite.config to generate relative asset URLs

Update server `updateBasePathInFrontend` to handle relative paths

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [ ] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
