### PR TITLE
fix(domain): make SanitizeString idempotent

### DIFF
--- a/internal/domain/sanitize.go
+++ b/internal/domain/sanitize.go
@@ -47,16 +47,25 @@ var reservedUserIdentifiers = map[string]struct{}{
 	CtxSystemDBMigrator: {},
 }
 
-// SanitizeString normalizes to NFC, trims leading and trailing whitespace, strips Unicode
-// control and format characters, drops invalid UTF-8 bytes, and truncates the result to
+// SanitizeString trims leading and trailing whitespace, strips Unicode control and format
+// characters, drops invalid UTF-8 bytes, normalizes to NFC, and truncates the result to
 // maxLen runes. If maxLen <= 0, returns "".
+//
+// The order matters and is load-bearing for idempotency: see the comments in the body.
+// SanitizeString(SanitizeString(s, n), n) == SanitizeString(s, n) for all s and n.
 func SanitizeString(s string, maxLen int) string {
 	if maxLen <= 0 {
 		return ""
 	}
 
-	s = norm.NFC.String(strings.TrimSpace(s))
+	s = strings.TrimSpace(s)
 
+	// Strip control/format characters and invalid UTF-8 *before* normalizing.
+	// Normalizing first is not idempotent: removing a character can leave a
+	// base letter next to a combining mark that the earlier normalization never
+	// saw as a pair. For example "A\t̀" is already NFC (the tab keeps the
+	// letter and the combining grave apart), but stripping the tab yields
+	// "À", which a second call would compose to "À".
 	var b strings.Builder
 	b.Grow(len(s))
 	for len(s) > 0 {
@@ -69,7 +78,10 @@ func SanitizeString(s string, maxLen int) string {
 			b.WriteRune(r)
 		}
 	}
-	s = b.String()
+
+	// Normalize before truncating, not after: composition can change the rune
+	// count, so normalizing afterwards could push the result back over maxLen.
+	s = norm.NFC.String(b.String())
 
 	if utf8.RuneCountInString(s) > maxLen {
 		runes := []rune(s)

--- a/internal/domain/sanitize_test.go
+++ b/internal/domain/sanitize_test.go
@@ -501,3 +501,39 @@ func TestPropertySanitizeIdentifierRejectsReservedValues(t *testing.T) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// Regression: normalization must run after control characters are stripped
+// ---------------------------------------------------------------------------
+
+// Found by TestPropertySanitizeStringIdempotent. Normalizing before stripping
+// control characters is not idempotent: "A\t̀" is already NFC because the
+// tab separates the letter from the combining grave, but removing the tab
+// leaves "À", which a second call composes to "À".
+func TestSanitizeStringNormalizesAfterStripping(t *testing.T) {
+	const input = "A\t\u0300" // "A", tab, combining grave accent
+
+	got := SanitizeString(input, 2)
+
+	if got != "À" {
+		t.Errorf("expected the combining mark to be composed after the tab is stripped, got %q (% x)",
+			got, []rune(got))
+	}
+	if again := SanitizeString(got, 2); again != got {
+		t.Errorf("not idempotent: once=%q twice=%q", got, again)
+	}
+}
+
+// The same hazard exists for format characters (category Cf), not just controls.
+func TestSanitizeStringStripsFormatCharsBeforeNormalizing(t *testing.T) {
+	const input = "A\u00ad\u0300" // "A", soft hyphen (Cf), combining grave accent
+
+	got := SanitizeString(input, 2)
+
+	if again := SanitizeString(got, 2); again != got {
+		t.Errorf("not idempotent: once=%q twice=%q", got, again)
+	}
+	if got != "À" {
+		t.Errorf("expected %q, got %q", "À", got)
+	}
+}


### PR DESCRIPTION
## Problem Statement

Found by `TestPropertySanitizeStringIdempotent`.

`SanitizeString` (`internal/domain/sanitize.go:53`) normalized to NFC before stripping control and format characters. Removing a character can leave a base letter next to a combining mark that the earlier normalization never saw as a pair, so a second call composes it and returns something different. Both results render as `À`, so here they are as codepoints:

```
input    U+0041 U+0009 U+0300   ("A", tab, combining grave)
once  -> U+0041 U+0300          (tab gone, still decomposed)
twice -> U+00C0                 (now composed)
```

Category Cf characters behave the same way, so it isn't specific to control characters.

Nothing in the tree sanitizes an already-sanitized value, so no caller hits this today. `SanitizeIdentifier` is built on  `SanitizeString`, and an identifier that comes out different on the second pass is a different user.

The ordering dates from 958dcb8, "feat: sanitize external identity provider user data (#681)", which is the only commit to touch this file

## Related Issue

None filed.

## Proposed Changes

The fix strips first, then normalizes. Normalization still runs before truncation, because composition changes the rune count and normalizing afterwards could push the result back over `maxLen` , which is the bound `TestPropertySanitizeStringOutputInvariants` asserts.

`TestSanitizeStringNormalizesAfterStripping` and `TestSanitizeStringStripsFormatCharsBeforeNormalizing` cover the two cases. Both fail against the old ordering. I re-ran the property suite at 50000 cases. The doc comment described the buggy order as the contract, and now states the real order and the idempotency guarantee.

The same reordering changes what comes out for inputs that were never valid UTF-8 to begin with, which is worth being clear about because it affects upgrades. I diffed the two orderings over 300000 random byte strings: 6 inputs differ, 5 of them ill-formed, and every difference is the composition above rather than anything specific to the invalid bytes. `"N\x17\u0301"` gave `U+004E U+0301` before and gives `U+0143` now; `"e\xb9\u030C"` gave `U+0065 U+030C` and now gives `U+011B`. The stray byte sat between the base letter and the mark and blocked composition, exactly as the tab does.

So an identifier stored under the old code can sanitize differently under the new one and by the same argument as above that reads as a different user. It needs a directory value with an invalid byte or a control character adjacent to a
combining mark, which I would not expect in a real `uid`, but the upgrade is not a pure no-op.

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
