### PR TITLE
fix(ldap): do not create interfaces from interface_filter entries

### DIFF
--- a/internal/app/users/ldap_interface_filter_test.go
+++ b/internal/app/users/ldap_interface_filter_test.go
@@ -1,0 +1,125 @@
+package users
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/h44z/wg-portal/internal/config"
+	"github.com/h44z/wg-portal/internal/domain"
+)
+
+// fakeInterfaceRepo records what the sync asked of the interface store.
+type fakeInterfaceRepo struct {
+	existing map[domain.InterfaceIdentifier]*domain.Interface
+	getErr   error
+	saved    map[domain.InterfaceIdentifier]*domain.Interface
+}
+
+func (f *fakeInterfaceRepo) GetInterface(
+	_ context.Context,
+	id domain.InterfaceIdentifier,
+) (*domain.Interface, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if iface, ok := f.existing[id]; ok {
+		return iface, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (f *fakeInterfaceRepo) SaveInterface(
+	_ context.Context,
+	id domain.InterfaceIdentifier,
+	updateFunc func(i *domain.Interface) (*domain.Interface, error),
+) error {
+	existing, ok := f.existing[id]
+	if !ok {
+		// Mirror the real repo, which creates the row when it is missing. The
+		// point of the guard under test is that we never get here for an
+		// interface that does not exist.
+		existing = &domain.Interface{Identifier: id}
+	}
+	updated, err := updateFunc(existing)
+	if err != nil {
+		return err
+	}
+	if f.saved == nil {
+		f.saved = make(map[domain.InterfaceIdentifier]*domain.Interface)
+	}
+	f.saved[id] = updated
+	return nil
+}
+
+func newFilterTestManager(repo *fakeInterfaceRepo) Manager {
+	return Manager{cfg: &config.Config{}, interfaces: repo}
+}
+
+// An interface_filter entry naming an interface wg-portal does not know about
+// must not bring that interface into existence. Creating it races the startup
+// importer, which then fails with "interface already exists", and the row it
+// leaves behind has no backend.
+func TestApplyInterfaceLdapFilterDoesNotCreateInterfaces(t *testing.T) {
+	repo := &fakeInterfaceRepo{existing: map[domain.InterfaceIdentifier]*domain.Interface{}}
+	m := newFilterTestManager(repo)
+
+	m.applyInterfaceLdapFilter(context.Background(), "wg0", "ipa",
+		[]domain.UserIdentifier{"alice"})
+
+	assert.Empty(t, repo.saved, "an unknown interface must not be created or written to")
+}
+
+func TestApplyInterfaceLdapFilterUpdatesExistingInterfaces(t *testing.T) {
+	repo := &fakeInterfaceRepo{existing: map[domain.InterfaceIdentifier]*domain.Interface{
+		"wg0": {Identifier: "wg0", Backend: "opnsense1"},
+	}}
+	m := newFilterTestManager(repo)
+
+	m.applyInterfaceLdapFilter(context.Background(), "wg0", "ipa",
+		[]domain.UserIdentifier{"alice", "bob"})
+
+	require.Contains(t, repo.saved, domain.InterfaceIdentifier("wg0"))
+	assert.Equal(t, []domain.UserIdentifier{"alice", "bob"},
+		repo.saved["wg0"].LdapAllowedUsers["ipa"])
+	assert.Equal(t, domain.InterfaceBackend("opnsense1"), repo.saved["wg0"].Backend,
+		"the existing interface must be updated in place, not replaced")
+}
+
+// Several providers may filter the same interface; one must not clobber another.
+func TestApplyInterfaceLdapFilterKeepsOtherProviders(t *testing.T) {
+	repo := &fakeInterfaceRepo{existing: map[domain.InterfaceIdentifier]*domain.Interface{
+		"wg0": {
+			Identifier: "wg0",
+			LdapAllowedUsers: map[string][]domain.UserIdentifier{
+				"other": {"carol"},
+			},
+		},
+	}}
+	m := newFilterTestManager(repo)
+
+	m.applyInterfaceLdapFilter(context.Background(), "wg0", "ipa",
+		[]domain.UserIdentifier{"alice"})
+
+	saved := repo.saved["wg0"].LdapAllowedUsers
+	assert.Equal(t, []domain.UserIdentifier{"alice"}, saved["ipa"])
+	assert.Equal(t, []domain.UserIdentifier{"carol"}, saved["other"],
+		"another provider's allowed users must be left alone")
+}
+
+// A lookup failure that is not "not found" must also not fall through to a
+// write, or a transient database error would silently create the interface.
+func TestApplyInterfaceLdapFilterSkipsOnLookupError(t *testing.T) {
+	repo := &fakeInterfaceRepo{
+		existing: map[domain.InterfaceIdentifier]*domain.Interface{},
+		getErr:   assert.AnError,
+	}
+	m := newFilterTestManager(repo)
+
+	m.applyInterfaceLdapFilter(context.Background(), "wg0", "ipa",
+		[]domain.UserIdentifier{"alice"})
+
+	assert.Empty(t, repo.saved, "a lookup error must not result in a write")
+}

--- a/internal/app/users/ldap_sync.go
+++ b/internal/app/users/ldap_sync.go
@@ -281,28 +281,53 @@ func (m Manager) updateInterfaceLdapFilters(
 			}
 		}
 
-		// Save the interface
-		err = m.interfaces.SaveInterface(ctx, ifaceId, func(i *domain.Interface) (*domain.Interface, error) {
-			if i.LdapAllowedUsers == nil {
-				i.LdapAllowedUsers = make(map[string][]domain.UserIdentifier)
-			}
-			i.LdapAllowedUsers[provider.ProviderName] = matchedUserIds
-			return i, nil
-		})
-		if err != nil {
-			slog.Error("failed to save interface ldap allowed users",
-				"interface", ifaceId,
-				"provider", provider.ProviderName,
-				"error", err)
-		} else {
-			slog.Debug("updated interface ldap allowed users",
-				"interface", ifaceId,
-				"provider", provider.ProviderName,
-				"matched_count", len(matchedUserIds))
-		}
+		m.applyInterfaceLdapFilter(ctx, ifaceId, provider.ProviderName, matchedUserIds)
 	}
 
 	return nil
+}
+
+// applyInterfaceLdapFilter stores the users an LDAP filter matched onto an
+// existing interface.
+//
+// It deliberately does not create the interface. SaveInterface would, which is
+// wrong twice over: an interface_filter entry is a statement about who may use
+// an interface, not a reason to bring one into existence, and the row it
+// creates has no backend. It also races the startup importer, which snapshots
+// the interface list before its device round-trips and then fails with
+// "interface already exists" once it finds the row.
+func (m Manager) applyInterfaceLdapFilter(
+	ctx context.Context,
+	ifaceId domain.InterfaceIdentifier,
+	providerName string,
+	matchedUserIds []domain.UserIdentifier,
+) {
+	if _, err := m.interfaces.GetInterface(ctx, ifaceId); err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			slog.Warn("skipping interface filter for unknown interface",
+				"interface", ifaceId, "provider", providerName)
+		} else {
+			slog.Error("failed to look up interface for ldap filter",
+				"interface", ifaceId, "provider", providerName, "error", err)
+		}
+		return
+	}
+
+	err := m.interfaces.SaveInterface(ctx, ifaceId, func(i *domain.Interface) (*domain.Interface, error) {
+		if i.LdapAllowedUsers == nil {
+			i.LdapAllowedUsers = make(map[string][]domain.UserIdentifier)
+		}
+		i.LdapAllowedUsers[providerName] = matchedUserIds
+		return i, nil
+	})
+	if err != nil {
+		slog.Error("failed to save interface ldap allowed users",
+			"interface", ifaceId, "provider", providerName, "error", err)
+		return
+	}
+
+	slog.Debug("updated interface ldap allowed users",
+		"interface", ifaceId, "provider", providerName, "matched_count", len(matchedUserIds))
 }
 
 func ldapUserIdentifier(rawUser map[string]any, field string) domain.UserIdentifier {

--- a/internal/app/users/user_manager.go
+++ b/internal/app/users/user_manager.go
@@ -40,6 +40,8 @@ type PeerDatabaseRepo interface {
 }
 
 type InterfaceDatabaseRepo interface {
+	// GetInterface returns the interface with the given identifier.
+	GetInterface(ctx context.Context, id domain.InterfaceIdentifier) (*domain.Interface, error)
 	// SaveInterface saves the interface with the given identifier.
 	SaveInterface(ctx context.Context, id domain.InterfaceIdentifier, updateFunc func(i *domain.Interface) (*domain.Interface, error)) error
 }


### PR DESCRIPTION
## Problem Statement

Bug in my `interface_filter` feature from #642. On a fresh database with `import_existing: true`, wg-portal panics on startup:

```console
panic: failed to import new interfaces: import of wg0 failed: interface already exists
        github.com/h44z/wg-portal/internal.AssertNoError(...)
                /internal/util.go:68
        main.main()
                /cmd/wg-portal/main.go:117
```

`updateInterfaceLdapFilters` saves the matched users with `SaveInterface`, which creates the interface if it is missing
([ldap_sync.go:285](https://github.com/h44z/wg-portal/blob/4a9bcd1/internal/app/users/ldap_sync.go#L285)). The sync goroutine starts at [main.go:85](https://github.com/h44z/wg-portal/blob/4a9bcd1/cmd/wg-portal/main.go#L85) and runs immediately. The import comes later, in [`app.Initialize`](https://github.com/h44z/wg-portal/blob/4a9bcd1/cmd/wg-portal/main.go#L116). So the sync can write a stub row for an `interface_filter` key before the interface exists.

`ImportNewInterfaces` snapshots the interface list ([wireguard_interfaces.go:114](https://github.com/h44z/wg-portal/blob/4a9bcd1/internal/app/wireguard/wireguard_interfaces.go#L114)) and then does its device round-trips, so where that write lands decides the outcome. Before the snapshot, the importer skips the interface and it is never imported. After the snapshot but before the insert, the panic above. After the import, nothing. The window is  `GetInterfaces` plus `GetPeers`. With 389-ds on localhost I hit the panic consistently.

The stub row is wrong either way, because it has no backend, so a typo in an `interface_filter` key silently creates an interface attached to no controller:

```
wg0 | backend=          | created_by=_WG_SYS_LDAP_SYNCER_
wg0 | backend=opnsense1 | created_by=_WG_SYS_WG_IMPORTER_
```

The sync-then-import ordering goes back to [8b820a5](https://github.com/h44z/wg-portal/commit/8b820a5) and the snapshot loop to [765fb09](https://github.com/h44z/wg-portal/commit/765fb09). #642 added a writer to a path that already had a racy reader. Affects v2.2.2 onward, and stubs already written stay, since the importer skips those interfaces.

## Related Issue

None filed. Introduced by #642.

## Proposed Changes

Make `updateInterfaceLdapFilters` update-only: look the interface up, skip with a warning when it is absent, skip at error level if the lookup fails for any other reason. The filter applies on the next sync once the importer has created it.

That leaves a first-start window where a filtered interface has an empty allow-list and `IsUserAllowed` denies non-admins until the next sync. Safe direction and it clears itself, but it is new behaviour where before it panicked.

The apply step moves into `applyInterfaceLdapFilter` so it can be tested without LDAP, covering unknown interface, existing interface, two providers on one interface and lookup error. The first fails against the old code. On the testbed a fresh database with `interface_filter` set now starts, imports with the right backends, and applies the filters on the next sync.

Importing before starting the sync goroutine would still leave the stub rows, and letting `importInterface` tolerate "already exists" only hides them.

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
