### PR TITLE
feat(config): add `startup_timeout` option with context propagation

### DIFF
--- a/cmd/wg-portal/main.go
+++ b/cmd/wg-portal/main.go
@@ -113,7 +113,7 @@ func main() {
 	internal.AssertNoError(err)
 	webhookManager.StartBackgroundJobs(ctx)
 
-	err = app.Initialize(cfg, wireGuardManager, userManager)
+	err = app.Initialize(ctx, cfg, wireGuardManager, userManager)
 	internal.AssertNoError(err)
 
 	validatorManager := validator.New()

--- a/docs/documentation/configuration/overview.md
+++ b/docs/documentation/configuration/overview.md
@@ -45,6 +45,7 @@ advanced:
   route_table_offset: 20000
   api_admin_only: true
   limit_additional_user_peers: 0
+  startup_timeout: 5m
 
 database:
   debug: false
@@ -362,6 +363,12 @@ Additional or more specialized configuration options for logging and interface c
 - **Default:** `0`
 - **Environment Variable:** `WG_PORTAL_ADVANCED_LIMIT_ADDITIONAL_USER_PEERS`
 - **Description:** Limit additional peers a normal user can create. `0` means unlimited.
+
+### `startup_timeout`
+- **Default:** `5m`
+- **Environment Variable:** `WG_PORTAL_ADVANCED_STARTUP_TIMEOUT`
+- **Description:** Timeout for the application startup process. 
+  Increase this value if you are using a MikroTik backend with many clients.
 
 ---
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -35,6 +35,7 @@ type App struct {
 
 // Initialize creates a new App instance and initializes it.
 func Initialize(
+	ctx context.Context,
 	cfg *config.Config,
 	wg WireGuardManager,
 	users UserManager,
@@ -46,7 +47,7 @@ func Initialize(
 		users: users,
 	}
 
-	startupContext, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	startupContext, cancel := context.WithTimeout(ctx, cfg.Advanced.StartupTimeout)
 	defer cancel()
 
 	// Switch to admin user context

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 		RouteTableOffset         int           `yaml:"route_table_offset"`
 		ApiAdminOnly             bool          `yaml:"api_admin_only"` // if true, only admin users can access the API
 		LimitAdditionalUserPeers int           `yaml:"limit_additional_user_peers"`
+		StartupTimeout           time.Duration `yaml:"startup_timeout"`
 	} `yaml:"advanced"`
 
 	Backend Backend `yaml:"backend"`
@@ -190,6 +191,7 @@ func defaultConfig() *Config {
 	cfg.Advanced.RouteTableOffset = getEnvInt("WG_PORTAL_ADVANCED_ROUTE_TABLE_OFFSET", 20000)
 	cfg.Advanced.ApiAdminOnly = getEnvBool("WG_PORTAL_ADVANCED_API_ADMIN_ONLY", true)
 	cfg.Advanced.LimitAdditionalUserPeers = getEnvInt("WG_PORTAL_ADVANCED_LIMIT_ADDITIONAL_USER_PEERS", 0)
+	cfg.Advanced.StartupTimeout = getEnvDuration("WG_PORTAL_ADVANCED_STARTUP_TIMEOUT", 5*time.Minute)
 
 	cfg.Statistics.UsePingChecks = getEnvBool("WG_PORTAL_STATISTICS_USE_PING_CHECKS", true)
 	cfg.Statistics.PingCheckWorkers = getEnvInt("WG_PORTAL_STATISTICS_PING_CHECK_WORKERS", 10)


### PR DESCRIPTION
## Related Issue

Fixes #739


## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
