### PR TITLE
chore(ui): use human readable transfer size for total bytes sent/received

### DIFF
--- a/frontend/src/components/PeerViewModal.vue
+++ b/frontend/src/components/PeerViewModal.vue
@@ -12,6 +12,7 @@ import { settingsStore } from "@/stores/settings";
 import { profileStore } from "@/stores/profile";
 import { base64_url_encode } from '@/helpers/encoding';
 import { apiWrapper } from "@/helpers/fetch-wrapper";
+import {humanFileSize} from '@/helpers/utils';
 
 const { t } = useI18n()
 
@@ -194,8 +195,8 @@ function ConfigQrUrl() {
                 <div class="col-md-12">
                   <h4>{{ $t('modals.peer-view.traffic') }}</h4>
                   <p><i class="fas fa-long-arrow-alt-down" :title="$t('modals.peer-view.download')"></i> {{
-                    selectedStats.BytesReceived }} Bytes / <i class="fas fa-long-arrow-alt-up"
-                      :title="$t('modals.peer-view.upload')"></i> {{ selectedStats.BytesTransmitted }} Bytes</p>
+                    humanFileSize(selectedStats.BytesReceived) }} / <i class="fas fa-long-arrow-alt-up"
+                      :title="$t('modals.peer-view.upload')"></i> {{ humanFileSize(selectedStats.BytesTransmitted) }}</p>
                   <h4>{{ $t('modals.peer-view.connection-status') }}</h4>
                   <ul>
                     <li>{{ $t('modals.peer-view.pingable') }}: {{ selectedStats.IsPingable }}</li>


### PR DESCRIPTION
## Problem Statement

Currently, when you view the total transferred data in/out for a client it shows the data as bytes. This PR translates that to human readable B/KB/MB/GB... etc

## Related Issue

Fixes #...

## Proposed Changes

Change the current "x Bytes" display to something like "x MB" for easier readability. See below

<img width="1337" height="506" alt="image" src="https://github.com/user-attachments/assets/d27e6d8e-fd8b-4a71-ba68-e385d6b9a4a4" />


## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
