### PR TITLE
feat(ldap): optionally revoke interface access when a filter stops matching

### DIFF
--- a/docs/documentation/configuration/overview.md
+++ b/docs/documentation/configuration/overview.md
@@ -857,6 +857,29 @@ Below are the properties for each LDAP provider entry inside `auth.ldap`:
     wg0: "(memberOf=CN=VPNUsers,OU=Groups,DC=COMPANY,DC=LOCAL)"
     wg1: "(description=special-access)"
   ```
+  Note that this is an *admission* check: it decides whether a user may obtain a
+  peer on the interface. On its own it does not withdraw peers a user already
+  holds if they later stop matching the filter — see `revoke_on_filter_change`.
+  An interface with no entry in this map is unrestricted.
+
+#### `revoke_on_filter_change`
+- **Default:** `false`
+- **Description:** If `true`, a user's peers on an interface are disabled once
+  they no longer match that interface's `interface_filter`. Without it the
+  filter only prevents *new* peers, and peers issued while the user still
+  matched keep working indefinitely, which matters if you use one interface per
+  access tier.
+  Only peers that belong to a user are affected; peers imported from a device or
+  created by an administrator have no owner and are left alone.
+  The reverse also applies: if the user matches the filter again later, peers
+  that were revoked this way are re-enabled on the next sync. Peers disabled for
+  any other reason are not touched.
+  Nothing is revoked if the provider's synchronization returned no usable user
+  identifiers at all, so a broken `base_dn`, an unreachable replica or a
+  `field_map` naming an attribute the server does not return cannot disable a
+  whole interface. Note this is judged per provider, not per filter: a filter
+  that matches nobody while the directory is otherwise answering is treated as
+  an empty tier, and its peers are revoked.
 
 #### `admin_group`
 - **Default:** *(empty)*

--- a/internal/app/eventbus.go
+++ b/internal/app/eventbus.go
@@ -18,6 +18,7 @@ const TopicUserApiDisabled = "user:api:disabled"
 const TopicUserRegistered = "user:registered"
 const TopicUserDisabled = "user:disabled"
 const TopicUserEnabled = "user:enabled"
+const TopicInterfaceLdapFilterApplied = "interface:ldapfilter:applied"
 
 // endregion user-events
 

--- a/internal/app/users/ldap_interface_filter_test.go
+++ b/internal/app/users/ldap_interface_filter_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/h44z/wg-portal/internal"
 	"github.com/h44z/wg-portal/internal/config"
 	"github.com/h44z/wg-portal/internal/domain"
 )
@@ -54,8 +55,25 @@ func (f *fakeInterfaceRepo) SaveInterface(
 	return nil
 }
 
+// recordingBus captures published events so the reconcile trigger can be
+// asserted without wiring up the wireguard manager.
+type recordingBus struct{ published []publishedEvent }
+
+type publishedEvent struct {
+	topic string
+	args  []any
+}
+
+func (b *recordingBus) Publish(topic string, args ...any) {
+	b.published = append(b.published, publishedEvent{topic: topic, args: args})
+}
+
 func newFilterTestManager(repo *fakeInterfaceRepo) Manager {
-	return Manager{cfg: &config.Config{}, interfaces: repo}
+	return Manager{cfg: &config.Config{}, interfaces: repo, bus: &recordingBus{}}
+}
+
+func testProvider(revoke bool) *config.LdapProvider {
+	return &config.LdapProvider{ProviderName: "ipa", RevokeOnFilterChange: revoke}
 }
 
 // An interface_filter entry naming an interface wg-portal does not know about
@@ -66,8 +84,8 @@ func TestApplyInterfaceLdapFilterDoesNotCreateInterfaces(t *testing.T) {
 	repo := &fakeInterfaceRepo{existing: map[domain.InterfaceIdentifier]*domain.Interface{}}
 	m := newFilterTestManager(repo)
 
-	m.applyInterfaceLdapFilter(context.Background(), "wg0", "ipa",
-		[]domain.UserIdentifier{"alice"})
+	m.applyInterfaceLdapFilter(context.Background(), "wg0", testProvider(false),
+		[]domain.UserIdentifier{"alice"}, true)
 
 	assert.Empty(t, repo.saved, "an unknown interface must not be created or written to")
 }
@@ -78,8 +96,8 @@ func TestApplyInterfaceLdapFilterUpdatesExistingInterfaces(t *testing.T) {
 	}}
 	m := newFilterTestManager(repo)
 
-	m.applyInterfaceLdapFilter(context.Background(), "wg0", "ipa",
-		[]domain.UserIdentifier{"alice", "bob"})
+	m.applyInterfaceLdapFilter(context.Background(), "wg0", testProvider(false),
+		[]domain.UserIdentifier{"alice", "bob"}, true)
 
 	require.Contains(t, repo.saved, domain.InterfaceIdentifier("wg0"))
 	assert.Equal(t, []domain.UserIdentifier{"alice", "bob"},
@@ -100,8 +118,8 @@ func TestApplyInterfaceLdapFilterKeepsOtherProviders(t *testing.T) {
 	}}
 	m := newFilterTestManager(repo)
 
-	m.applyInterfaceLdapFilter(context.Background(), "wg0", "ipa",
-		[]domain.UserIdentifier{"alice"})
+	m.applyInterfaceLdapFilter(context.Background(), "wg0", testProvider(false),
+		[]domain.UserIdentifier{"alice"}, true)
 
 	saved := repo.saved["wg0"].LdapAllowedUsers
 	assert.Equal(t, []domain.UserIdentifier{"alice"}, saved["ipa"])
@@ -118,8 +136,89 @@ func TestApplyInterfaceLdapFilterSkipsOnLookupError(t *testing.T) {
 	}
 	m := newFilterTestManager(repo)
 
-	m.applyInterfaceLdapFilter(context.Background(), "wg0", "ipa",
-		[]domain.UserIdentifier{"alice"})
+	m.applyInterfaceLdapFilter(context.Background(), "wg0", testProvider(false),
+		[]domain.UserIdentifier{"alice"}, true)
 
 	assert.Empty(t, repo.saved, "a lookup error must not result in a write")
+}
+
+// With revoke_on_filter_change on, the resulting allowed set is published so a
+// consumer can reconcile the interface's peers against it.
+func TestApplyInterfaceLdapFilterPublishesEntitlement(t *testing.T) {
+	repo := &fakeInterfaceRepo{existing: map[domain.InterfaceIdentifier]*domain.Interface{
+		"wg1": {Identifier: "wg1", LdapAllowedUsers: map[string][]domain.UserIdentifier{"ipa": {"alice", "bob"}}},
+	}}
+	m := newFilterTestManager(repo)
+	bus := m.bus.(*recordingBus)
+
+	m.applyInterfaceLdapFilter(context.Background(), "wg1", testProvider(true),
+		[]domain.UserIdentifier{"alice"}, true)
+
+	require.Len(t, bus.published, 1)
+	assert.Equal(t, "interface:ldapfilter:applied", bus.published[0].topic)
+	assert.Equal(t, domain.InterfaceIdentifier("wg1"), bus.published[0].args[0])
+	assert.Equal(t, []domain.UserIdentifier{"alice"}, bus.published[0].args[1],
+		"the whole allowed set is published, not a diff, so reconciliation is idempotent")
+}
+
+// A tier whose last member leaves is not a broken filter: the directory is
+// answering, it just matches nobody now. The empty set must still be published
+// or the departing user keeps working access.
+func TestApplyInterfaceLdapFilterPublishesEmptyTier(t *testing.T) {
+	repo := &fakeInterfaceRepo{existing: map[domain.InterfaceIdentifier]*domain.Interface{
+		"wg1": {Identifier: "wg1", LdapAllowedUsers: map[string][]domain.UserIdentifier{"ipa": {"bob"}}},
+	}}
+	m := newFilterTestManager(repo)
+	bus := m.bus.(*recordingBus)
+
+	m.applyInterfaceLdapFilter(context.Background(), "wg1", testProvider(true), nil, true)
+
+	require.Len(t, bus.published, 1, "an emptied tier must still be reconciled")
+	assert.Empty(t, bus.published[0].args[1])
+}
+
+// Off by default, so upgrading does not suddenly start disabling peers.
+func TestApplyInterfaceLdapFilterDoesNotPublishWhenDisabled(t *testing.T) {
+	repo := &fakeInterfaceRepo{existing: map[domain.InterfaceIdentifier]*domain.Interface{
+		"wg1": {Identifier: "wg1", LdapAllowedUsers: map[string][]domain.UserIdentifier{"ipa": {"alice", "bob"}}},
+	}}
+	m := newFilterTestManager(repo)
+	bus := m.bus.(*recordingBus)
+
+	m.applyInterfaceLdapFilter(context.Background(), "wg1", testProvider(false),
+		[]domain.UserIdentifier{"alice"}, true)
+
+	assert.Empty(t, bus.published, "reconciliation is opt-in")
+}
+
+// If the directory returned no users at all the whole sync is suspect, so
+// nothing is published and no peer is reconciled away.
+func TestApplyInterfaceLdapFilterSilentWhenDirectoryReturnedNothing(t *testing.T) {
+	repo := &fakeInterfaceRepo{existing: map[domain.InterfaceIdentifier]*domain.Interface{
+		"wg1": {Identifier: "wg1", LdapAllowedUsers: map[string][]domain.UserIdentifier{"ipa": {"alice", "bob"}}},
+	}}
+	m := newFilterTestManager(repo)
+	bus := m.bus.(*recordingBus)
+
+	m.applyInterfaceLdapFilter(context.Background(), "wg1", testProvider(true), nil, false)
+
+	assert.Empty(t, bus.published,
+		"an unhealthy directory must not revoke every peer on the interface")
+}
+
+// A field map naming an attribute the server does not return yields entries with
+// no identifier. That tells the sync nothing about who is entitled, so it must
+// not be mistaken for a directory that answered and happens to be empty --
+// otherwise an empty filter revokes every owned peer on the interface.
+func TestHasUsableIdentifiersIgnoresEntriesWithoutIdentifier(t *testing.T) {
+	fields := makeTestLdapFields()
+
+	withIds := []internal.RawLdapUser{{"uid": "alice"}, {"uid": "bob"}}
+	assert.True(t, hasUsableIdentifiers(withIds, fields))
+
+	// Entries came back, but the identifier attribute is absent from all of them.
+	withoutIds := []internal.RawLdapUser{{"cn": "alice"}, {"cn": "bob"}}
+	assert.False(t, hasUsableIdentifiers(withoutIds, fields))
+
+	assert.False(t, hasUsableIdentifiers(nil, fields))
 }

--- a/internal/app/users/ldap_sync.go
+++ b/internal/app/users/ldap_sync.go
@@ -90,8 +90,12 @@ func (m Manager) synchronizeLdapUsers(ctx context.Context, provider *config.Ldap
 		}
 	}
 
-	// Update interface allowed users based on LDAP filters
-	err = m.updateInterfaceLdapFilters(ctx, conn, provider)
+	// Update interface allowed users based on LDAP filters. The flag says whether
+	// the directory answered usefully, so it counts entries we could extract an
+	// identifier from: a field map naming an attribute the server does not return
+	// yields entries with empty identifiers, which tells us nothing about who is
+	// entitled and must not be read as "the tier is empty".
+	err = m.updateInterfaceLdapFilters(ctx, conn, provider, hasUsableIdentifiers(rawUsers, &provider.FieldMap))
 	if err != nil {
 		return err
 	}
@@ -283,6 +287,7 @@ func (m Manager) updateInterfaceLdapFilters(
 	ctx context.Context,
 	conn *ldap.Conn,
 	provider *config.LdapProvider,
+	directoryReturnedUsers bool,
 ) error {
 	if len(provider.InterfaceFilter) == 0 {
 		return nil // nothing to do if no interfaces are configured for this provider
@@ -311,7 +316,7 @@ func (m Manager) updateInterfaceLdapFilters(
 			}
 		}
 
-		m.applyInterfaceLdapFilter(ctx, ifaceId, provider.ProviderName, matchedUserIds)
+		m.applyInterfaceLdapFilter(ctx, ifaceId, provider, matchedUserIds, directoryReturnedUsers)
 	}
 
 	return nil
@@ -329,9 +334,11 @@ func (m Manager) updateInterfaceLdapFilters(
 func (m Manager) applyInterfaceLdapFilter(
 	ctx context.Context,
 	ifaceId domain.InterfaceIdentifier,
-	providerName string,
+	provider *config.LdapProvider,
 	matchedUserIds []domain.UserIdentifier,
+	directoryReturnedUsers bool,
 ) {
+	providerName := provider.ProviderName
 	if _, err := m.interfaces.GetInterface(ctx, ifaceId); err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
 			slog.Warn("skipping interface filter for unknown interface",
@@ -358,6 +365,41 @@ func (m Manager) applyInterfaceLdapFilter(
 
 	slog.Debug("updated interface ldap allowed users",
 		"interface", ifaceId, "provider", providerName, "matched_count", len(matchedUserIds))
+
+	if !provider.RevokeOnFilterChange {
+		return
+	}
+
+	// An interface filter matching nobody is ambiguous: the group may genuinely
+	// have emptied, or the filter may be broken, the group renamed, or a replica
+	// unpopulated. The provider-level sync result disambiguates it. If the
+	// directory returned users at all it is answering correctly, so an empty
+	// filter means the tier really is empty. If it returned nothing the whole
+	// sync is suspect and nothing should be revoked on the strength of it.
+	if len(matchedUserIds) == 0 && !directoryReturnedUsers {
+		slog.Error("refusing to reconcile interface access: the directory returned no users at all",
+			"interface", ifaceId, "provider", providerName)
+		return
+	}
+
+	// Publish the resulting entitlement rather than a diff against the previous
+	// one. A diff only fires on the sync that happens to observe the change, so
+	// a demotion while wg-portal is stopped would never be acted on. Handing
+	// over the whole allowed set lets the consumer reconcile from current state,
+	// which is idempotent and repairs existing drift.
+	m.bus.Publish(app.TopicInterfaceLdapFilterApplied, ifaceId, matchedUserIds)
+}
+
+// hasUsableIdentifiers reports whether at least one entry carried an identifier.
+// Entries alone are not enough: they can come back with the identifier attribute
+// missing, in which case the sync knows nothing about who is entitled.
+func hasUsableIdentifiers(rawUsers []internal.RawLdapUser, fields *config.LdapFields) bool {
+	for _, rawUser := range rawUsers {
+		if ldapUserIdentifier(rawUser, fields.UserIdentifier) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func ldapUserIdentifier(rawUser map[string]any, field string) domain.UserIdentifier {

--- a/internal/app/wireguard/wireguard.go
+++ b/internal/app/wireguard/wireguard.go
@@ -96,6 +96,7 @@ func (m Manager) connectToMessageBus() {
 	_ = m.bus.Subscribe(app.TopicUserDisabled, m.handleUserDisabledEvent)
 	_ = m.bus.Subscribe(app.TopicUserEnabled, m.handleUserEnabledEvent)
 	_ = m.bus.Subscribe(app.TopicUserDeleted, m.handleUserDeletedEvent)
+	_ = m.bus.Subscribe(app.TopicInterfaceLdapFilterApplied, m.handleInterfaceLdapFilterAppliedEvent)
 	_ = m.bus.Subscribe(app.TopicInterfaceCreated, m.handleInterfaceCreatedEvent)
 }
 
@@ -181,6 +182,80 @@ func (m Manager) handleUserDisabledEvent(user domain.User) {
 				"peer", peer.Identifier,
 				"user", user.Identifier,
 				"error", err)
+		}
+	}
+}
+
+// handleInterfaceLdapFilterAppliedEvent reconciles the peers on one interface
+// against the users its LDAP filter currently permits, disabling any that are
+// no longer entitled.
+//
+// It works from the resulting allowed set rather than a diff of what changed,
+// so it is idempotent and also repairs drift that occurred while wg-portal was
+// not running: a demotion during downtime is invisible to a transition-based
+// check but is caught by the next reconcile.
+//
+// Only peers owned by a user are considered. Peers imported from a device or
+// created by an administrator have no owner and are not governed by the filter.
+func (m Manager) handleInterfaceLdapFilterAppliedEvent(
+	interfaceId domain.InterfaceIdentifier,
+	allowedUserIds []domain.UserIdentifier,
+) {
+	ctx := domain.SetUserInfo(context.Background(), domain.SystemAdminContextUserInfo())
+
+	peers, err := m.db.GetInterfacePeers(ctx, interfaceId)
+	if err != nil {
+		slog.Error("failed to retrieve peers while reconciling interface access",
+			"interface", interfaceId, "error", err)
+		return
+	}
+
+	allowed := make(map[domain.UserIdentifier]struct{}, len(allowedUserIds))
+	for _, id := range allowedUserIds {
+		allowed[id] = struct{}{}
+	}
+
+	now := time.Now()
+	for _, peer := range peers {
+		if peer.UserIdentifier == "" {
+			continue // not owned by a user, so no filter governs it
+		}
+		if _, ok := allowed[peer.UserIdentifier]; ok {
+			// Entitled again. Undo a revocation this handler performed earlier,
+			// so that moving a user back into the group restores their access;
+			// peers disabled for any other reason are left to their own owner.
+			if peer.DisabledReason != domain.DisabledReasonAccessRevoked {
+				continue
+			}
+
+			slog.Info("re-enabling peer, user is permitted on this interface again",
+				"peer", peer.Identifier, "user", peer.UserIdentifier, "interface", interfaceId)
+
+			peer.Disabled = nil
+			peer.DisabledReason = ""
+
+			if _, err := m.UpdatePeer(ctx, &peer); err != nil {
+				slog.Error("failed to re-enable peer after interface access was restored",
+					"peer", peer.Identifier, "user", peer.UserIdentifier,
+					"interface", interfaceId, "error", err)
+			}
+
+			continue
+		}
+		if peer.IsDisabled() {
+			continue
+		}
+
+		slog.Info("disabling peer, user no longer permitted on this interface",
+			"peer", peer.Identifier, "user", peer.UserIdentifier, "interface", interfaceId)
+
+		peer.Disabled = &now
+		peer.DisabledReason = domain.DisabledReasonAccessRevoked
+
+		if _, err := m.UpdatePeer(ctx, &peer); err != nil {
+			slog.Error("failed to disable peer after interface access was revoked",
+				"peer", peer.Identifier, "user", peer.UserIdentifier,
+				"interface", interfaceId, "error", err)
 		}
 	}
 }

--- a/internal/app/wireguard/wireguard_ldap_filter_test.go
+++ b/internal/app/wireguard/wireguard_ldap_filter_test.go
@@ -1,0 +1,110 @@
+package wireguard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/h44z/wg-portal/internal/config"
+	"github.com/h44z/wg-portal/internal/domain"
+)
+
+func filterTestManager(peers []domain.Peer) (Manager, *mockDB) {
+	byId := make(map[domain.PeerIdentifier]*domain.Peer, len(peers))
+	for i := range peers {
+		byId[peers[i].Identifier] = &peers[i]
+	}
+
+	db := &mockDB{
+		iface:          &domain.Interface{Identifier: "wg1", Type: domain.InterfaceTypeServer},
+		interfacePeers: peers,
+		peers:          byId,
+	}
+
+	return Manager{
+		cfg: &config.Config{},
+		bus: &mockBus{},
+		db:  db,
+		wg: &ControllerManager{
+			controllers: map[domain.InterfaceBackend]backendInstance{
+				config.LocalBackendName: {Implementation: &mockController{}},
+			},
+		},
+	}, db
+}
+
+// savedPeer returns the single peer the manager wrote, if any. The mock keys its
+// map by a field UpdatePeer does not carry through, so the count is what matters.
+func savedPeer(db *mockDB) *domain.Peer {
+	for _, p := range db.savedPeers {
+		return p
+	}
+	return nil
+}
+
+func ownedPeer(id domain.PeerIdentifier, owner domain.UserIdentifier) domain.Peer {
+	return domain.Peer{
+		Identifier:          id,
+		InterfaceIdentifier: "wg1",
+		UserIdentifier:      owner,
+		Interface:           domain.PeerInterfaceConfig{Type: domain.InterfaceTypeServer},
+		DisplayName:         string(id),
+	}
+}
+
+// A user who has dropped out of the filter loses the peer they already hold.
+func TestInterfaceLdapFilterApplied_RevokesPeerOfRemovedUser(t *testing.T) {
+	m, db := filterTestManager([]domain.Peer{ownedPeer("peer-bob", "bob")})
+
+	m.handleInterfaceLdapFilterAppliedEvent("wg1", []domain.UserIdentifier{"alice"})
+
+	saved := savedPeer(db)
+	require.NotNil(t, saved, "bob's peer should have been written")
+	assert.True(t, saved.IsDisabled())
+	assert.Equal(t, domain.DisabledReasonAccessRevoked, saved.DisabledReason)
+}
+
+// Revocation has to be reversible, or a demotion that is later undone leaves the
+// peer dead with nothing to bring it back.
+func TestInterfaceLdapFilterApplied_RestoresPeerWhenUserReturns(t *testing.T) {
+	revoked := time.Now().Add(-time.Hour)
+	peer := ownedPeer("peer-bob", "bob")
+	peer.Disabled = &revoked
+	peer.DisabledReason = domain.DisabledReasonAccessRevoked
+
+	m, db := filterTestManager([]domain.Peer{peer})
+
+	m.handleInterfaceLdapFilterAppliedEvent("wg1", []domain.UserIdentifier{"bob"})
+
+	saved := savedPeer(db)
+	require.NotNil(t, saved, "bob's peer should have been written")
+	assert.False(t, saved.IsDisabled())
+	assert.Empty(t, saved.DisabledReason)
+}
+
+// A peer an administrator disabled by hand must not be resurrected just because
+// its owner matches the filter.
+func TestInterfaceLdapFilterApplied_LeavesPeersDisabledForOtherReasons(t *testing.T) {
+	disabled := time.Now().Add(-time.Hour)
+	peer := ownedPeer("peer-bob", "bob")
+	peer.Disabled = &disabled
+	peer.DisabledReason = domain.DisabledReasonUserDisabled
+
+	m, db := filterTestManager([]domain.Peer{peer})
+
+	m.handleInterfaceLdapFilterAppliedEvent("wg1", []domain.UserIdentifier{"bob"})
+
+	assert.Empty(t, db.savedPeers, "a peer disabled for another reason must be left alone")
+}
+
+// Imported peers and peers an administrator created have no owner, so no filter
+// governs them.
+func TestInterfaceLdapFilterApplied_IgnoresPeersWithoutOwner(t *testing.T) {
+	m, db := filterTestManager([]domain.Peer{ownedPeer("peer-orphan", "")})
+
+	m.handleInterfaceLdapFilterAppliedEvent("wg1", []domain.UserIdentifier{"alice"})
+
+	assert.Empty(t, db.savedPeers, "an unowned peer must not be revoked")
+}

--- a/internal/app/wireguard/wireguard_peers_test.go
+++ b/internal/app/wireguard/wireguard_peers_test.go
@@ -58,10 +58,12 @@ func (f *mockController) PingAddresses(_ context.Context, _ string) (*domain.Pin
 }
 
 type mockDB struct {
-	savedPeers map[domain.PeerIdentifier]*domain.Peer
-	iface      *domain.Interface
-	interfaces []domain.Interface
-	users      []domain.User
+	savedPeers     map[domain.PeerIdentifier]*domain.Peer
+	iface          *domain.Interface
+	interfaces     []domain.Interface
+	users          []domain.User
+	peers          map[domain.PeerIdentifier]*domain.Peer
+	interfacePeers []domain.Peer
 }
 
 func (f *mockDB) GetInterface(ctx context.Context, id domain.InterfaceIdentifier) (*domain.Interface, error) {
@@ -108,7 +110,7 @@ func (f *mockDB) DeleteInterface(ctx context.Context, id domain.InterfaceIdentif
 	return nil
 }
 func (f *mockDB) GetInterfacePeers(ctx context.Context, id domain.InterfaceIdentifier) ([]domain.Peer, error) {
-	return nil, nil
+	return f.interfacePeers, nil
 }
 func (f *mockDB) GetUserPeers(ctx context.Context, id domain.UserIdentifier) ([]domain.Peer, error) {
 	return nil, nil
@@ -134,6 +136,9 @@ func (f *mockDB) SavePeer(
 }
 func (f *mockDB) DeletePeer(ctx context.Context, id domain.PeerIdentifier) error { return nil }
 func (f *mockDB) GetPeer(ctx context.Context, id domain.PeerIdentifier) (*domain.Peer, error) {
+	if peer, ok := f.peers[id]; ok {
+		return peer, nil
+	}
 	return nil, domain.ErrNotFound
 }
 func (f *mockDB) GetUsedIpsPerSubnet(ctx context.Context, subnets []domain.Cidr) (

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -218,6 +218,14 @@ type LdapProvider struct {
 	// Map key is the interface identifier (e.g., "wg0"), value is the filter string.
 	InterfaceFilter map[string]string `yaml:"interface_filter"`
 
+	// RevokeOnFilterChange disables a user's peers on an interface once they no
+	// longer match that interface's InterfaceFilter. Without it the filter is
+	// only an admission check: it prevents new peers, but peers issued while the
+	// user still matched keep working indefinitely.
+	// Opt-in, because enabling it by default would start disabling peers in
+	// existing deployments on upgrade.
+	RevokeOnFilterChange bool `yaml:"revoke_on_filter_change"`
+
 	// If LogUserInfo is set to true, the user info retrieved from the LDAP provider will be logged in trace level.
 	LogUserInfo bool `yaml:"log_user_info"`
 }

--- a/internal/domain/base.go
+++ b/internal/domain/base.go
@@ -59,6 +59,7 @@ const (
 	DisabledReasonLdapMissing      = "missing in ldap"
 	DisabledReasonMigrationDummy   = "migration dummy user"
 	DisabledReasonInterfaceMissing = "missing WireGuard interface"
+	DisabledReasonAccessRevoked    = "no longer permitted on this interface"
 
 	LockedReasonAdmin = "locked by admin"
 	LockedReasonApi   = "locked by admin"


### PR DESCRIPTION
## Problem Statement

`interface_filter` decides who can get a peer on an interface. Nothing reconciles the peers that already exist, which is the half I missed in #642. Take a user out of the filtered group and they can't get a new peer, but the one they already hold keeps working:

```
wg1 | {"ipa":[]}                 <- bob removed from staff
wg2 | {"ipa":["bob","carol"]}    <- bob added to restricted

peers: <pubkey> | wg1 | bob | disabled=None
device: peer still present and enabled on wg1
```

The entitlement gets recalculated every sync and then nothing acts on it. With one interface per tier, a demotion grants the new tier without withdrawing the old. On my testbed bob kept reaching an internal segment over the old staff tunnel long after both systems had him down as restricted, and it stays that way until someone deletes the peer by hand.

A user disappearing from LDAP altogether is already handled through [`TopicUserDisabled`](https://github.com/h44z/wg-portal/blob/7f5786f/internal/app/eventbus.go#L19). Losing filter membership isn't. Behaviour since #642 shipped in v2.2.2.

## Related Issue

None filed. Builds on #746, the `interface_filter` panic fix, which touched the same function. That one is merged, so this is a single commit on top of master.

## Proposed Changes

Adds `revoke_on_filter_change` next to `interface_filter` on the LDAP provider:

```yaml
auth:
  ldap:
    - id: ldap1
      revoke_on_filter_change: true   # default false
      interface_filter:
        wg1: "(memberOf=cn=vpn-staff,cn=groups,dc=example,dc=com)"
```

The sync publishes the interface's resulting allowed-user set on a new `TopicInterfaceLdapFilterApplied`, and the WireGuard manager disables peers whose owner isn't in it. Off by default, so upgrades change nothing.

It sends the whole set, not a diff, so a demotion made while wg-portal was stopped still gets acted on and existing drift gets repaired.

Revocation is reversible. If the user matches again the handler re-enables the peers it disabled, spotting them by the `DisabledReasonAccessRevoked` it wrote, so it won't resurrect something an admin switched off by hand. That reason string is new public surface, visible in the UI and API.

A filter matching nobody is ambiguous: either the tier emptied or the query broke. I go by whether the provider's sync produced any usable identifier at all. If it did, the tier really is empty and those peers go, otherwise nothing is revoked for that provider. Counting returned entries wouldn't do, because a `field_map.user_identifier` naming an attribute the server omits gives back entries with no identifier in them. #744 guards `disable_missing` the same way.

Two things this doesn't fix. The refusal above only stops revocation, since the allow-list is written first, so a filter matching nobody still blocks non-admins from provisioning. Fixing that belongs in
[`updateInterfaceLdapFilters`](https://github.com/h44z/wg-portal/blob/7f5786f/internal/app/users/ldap_sync.go#L282). And one broken filter on an otherwise healthy provider still looks like an emptied tier.

Peers with no owner are left alone, and [`IsUserAllowed`](https://github.com/h44z/wg-portal/blob/7f5786f/internal/domain/interface.go#L89) still returns true for an interface with no `interface_filter` entry, which is what makes unconfigured single-interface setups work, and that doesn't change.

Tests cover the publisher (empty tier against an unanswered directory, option off, broken field map) and the handler (revoke, restore, leave other disable reasons alone, ignore unowned peers). On a testbed of 389-ds, wg-portal and an
OPNsense box, moving a user from staff to restricted disabled their `wg1` peer on the next sync and the peer went to `enabled: 0` on the firewall, not just in the database.

## Checklist

- [x] Commits are signed with `git commit --signoff`
- [x] Changes have reasonable test coverage
- [x] Tests pass with `make test`
- [x] Helm docs are up-to-date with `make helm-docs`
